### PR TITLE
Fixing a circular import that only comes up when running Protenix

### DIFF
--- a/src/sampleworks/utils/__init__.py
+++ b/src/sampleworks/utils/__init__.py
@@ -1,7 +1,5 @@
 """Utility functions and helpers for sampleworks."""
 
-from typing import Any
-
 from sampleworks.utils.imports import (
     BOLTZ_AVAILABLE,
     check_any_model_available,
@@ -12,12 +10,6 @@ from sampleworks.utils.imports import (
     require_boltz,
     require_protenix,
 )
-
-
-def do_nothing(*args: Any, **kwargs: Any) -> None:
-    """Does nothing, just returns None"""
-    pass
-
 
 __all__ = [
     "BOLTZ_AVAILABLE",

--- a/src/sampleworks/utils/torch_utils.py
+++ b/src/sampleworks/utils/torch_utils.py
@@ -8,8 +8,6 @@ import numpy as np
 import torch
 
 from sampleworks import should_check_nans
-from sampleworks.utils import do_nothing
-
 
 DeviceLikeType = str | torch.device | int
 
@@ -146,6 +144,11 @@ def _assert_no_nans(x: Any, *, msg: str = "", fail_if_not_tensor: bool = False) 
             )
     elif fail_if_not_tensor:
         raise ValueError(f"Unsupported type: {type(x)}")
+
+
+def do_nothing(*args: Any, **kwargs: Any) -> None:
+    """Does nothing, just returns None"""
+    pass
 
 
 assert_no_nans = _assert_no_nans if should_check_nans else do_nothing


### PR DESCRIPTION
Quick small fix for a circular import I accidentally introduced a could PR's ago, it prevents Protenix from running.