### PR TITLE
fix: use protocol-based n_steps parsing in pure_guidance.py and fk_steering.py (closes #33)

### DIFF
--- a/src/sampleworks/core/scalers/fk_steering.py
+++ b/src/sampleworks/core/scalers/fk_steering.py
@@ -246,17 +246,7 @@ class FKSteering:
         trajectory_next_step = []
         losses = []
 
-        # TODO: this is not generalizable currently, figure this out
-        if hasattr(self.model_wrapper, "predict_args"):
-            n_steps = self.model_wrapper.predict_args.sampling_steps  # type: ignore
-        elif hasattr(self.model_wrapper, "configs"):
-            n_steps = cast(dict, self.model_wrapper.configs.sample_diffusion)["N_step"]  # type: ignore
-        elif hasattr(self.model_wrapper, "num_steps"):
-            n_steps = self.model_wrapper.num_steps  # type: ignore
-        else:
-            raise AttributeError(
-                "Model wrapper must have predict_args, configs, or num_steps attribute"
-            )
+        n_steps = len(cast(torch.Tensor, self.model_wrapper.get_noise_schedule()["sigma_t"]))
 
         pbar = tqdm(range(partial_diffusion_step, n_steps))
         for i in pbar:

--- a/src/sampleworks/core/scalers/pure_guidance.py
+++ b/src/sampleworks/core/scalers/pure_guidance.py
@@ -196,17 +196,7 @@ class PureGuidance:
         trajectory_next_step = []
         losses = []
 
-        # TODO: this is not generalizable currently, figure this out
-        if hasattr(self.model_wrapper, "predict_args"):
-            n_steps = self.model_wrapper.predict_args.sampling_steps  # type: ignore
-        elif hasattr(self.model_wrapper, "configs"):
-            n_steps = cast(dict, self.model_wrapper.configs.sample_diffusion)["N_step"]  # type: ignore
-        elif hasattr(self.model_wrapper, "num_steps"):
-            n_steps = self.model_wrapper.num_steps  # type: ignore
-        else:
-            raise AttributeError(
-                "Model wrapper must have predict_args, configs, or num_steps attribute"
-            )
+        n_steps = len(cast(torch.Tensor, self.model_wrapper.get_noise_schedule()["sigma_t"]))
 
         for i in tqdm(range(partial_diffusion_step, n_steps)):
             apply_guidance = i > guidance_start


### PR DESCRIPTION
Replace n_steps parsing by using the get_noise_schedule() method.
The `get_noise_schedule()["sigma_t"]` approach works for all DiffusionModelWrapper
implementations and is more extensible for new model wrappers.
