### PR TITLE
add ligand, water stripping and save the selected atoms as CIF in synthetic density generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,9 +213,9 @@ __marimo__/
 # AI
 .claude/
 CLAUDE.local.md
-CLAUDE.md
 .github/workflows/claude*.yml
 .github/agents/
+.pi/
 
 # Model checkpoints
 release_data/
@@ -223,3 +223,4 @@ release_data/
 # Large results from runs
 grid_search_results/
 outputs/
+initial_dataset_40/

--- a/src/sampleworks/utils/atom_array_utils.py
+++ b/src/sampleworks/utils/atom_array_utils.py
@@ -377,11 +377,12 @@ def keep_polymer(
             f"Unexpected type: {type(atom_array)}, can only accept AtomArray or AtomArrayStack"
         )
 
-    polymer_mask = filter_polymer(atom_array, pol_type=pol_type)
-
+    # TODO: fix once this is fixed: https://github.com/biotite-dev/biotite/issues/865
     if isinstance(atom_array, AtomArrayStack):
+        polymer_mask = filter_polymer(atom_array[0], pol_type=pol_type)
         return cast(AtomArrayStack, atom_array[:, polymer_mask])
     else:
+        polymer_mask = filter_polymer(atom_array, pol_type=pol_type)
         return cast(AtomArray, atom_array[polymer_mask])
 
 

--- a/src/sampleworks/utils/atom_array_utils.py
+++ b/src/sampleworks/utils/atom_array_utils.py
@@ -316,9 +316,9 @@ def select_altloc(
         mask = atom_array.altloc_id == altloc_id
 
     if isinstance(atom_array, AtomArrayStack):
-        return cast(AtomArrayStack, atom_array[:, mask])
+        return atom_array[:, mask]  # pyright: ignore[reportReturnType]
     else:
-        return cast(AtomArray, atom_array[mask])
+        return atom_array[mask]  # pyright: ignore[reportReturnType]
 
 
 def select_non_hetero(atom_array: AtomArray | AtomArrayStack) -> AtomArray | AtomArrayStack:
@@ -348,9 +348,9 @@ def select_non_hetero(atom_array: AtomArray | AtomArrayStack) -> AtomArray | Ato
     mask = ~hetero
 
     if isinstance(atom_array, AtomArrayStack):
-        return cast(AtomArrayStack, atom_array[:, mask])
+        return atom_array[:, mask]  # pyright: ignore[reportReturnType]
     else:
-        return cast(AtomArray, atom_array[mask])
+        return atom_array[mask]  # pyright: ignore[reportReturnType]
 
 
 def keep_polymer(
@@ -380,10 +380,10 @@ def keep_polymer(
     # TODO: fix once this is fixed: https://github.com/biotite-dev/biotite/issues/865
     if isinstance(atom_array, AtomArrayStack):
         polymer_mask = filter_polymer(atom_array[0], pol_type=pol_type)
-        return cast(AtomArrayStack, atom_array[:, polymer_mask])
+        return atom_array[:, polymer_mask]  # pyright: ignore[reportReturnType]
     else:
         polymer_mask = filter_polymer(atom_array, pol_type=pol_type)
-        return cast(AtomArray, atom_array[polymer_mask])
+        return atom_array[polymer_mask]  # pyright: ignore[reportReturnType]
 
 
 def keep_amino_acids(
@@ -410,9 +410,9 @@ def keep_amino_acids(
     amino_acid_mask = filter_amino_acids(atom_array)
 
     if isinstance(atom_array, AtomArrayStack):
-        return cast(AtomArrayStack, atom_array[:, amino_acid_mask])
+        return atom_array[:, amino_acid_mask]  # pyright: ignore[reportReturnType]
     else:
-        return cast(AtomArray, atom_array[amino_acid_mask])
+        return atom_array[amino_acid_mask]  # pyright: ignore[reportReturnType]
 
 
 def remove_hydrogens(atom_array: AtomArray | AtomArrayStack) -> AtomArray | AtomArrayStack:
@@ -440,9 +440,9 @@ def remove_hydrogens(atom_array: AtomArray | AtomArrayStack) -> AtomArray | Atom
     mask = (element != "H") & (element != "D")
 
     if isinstance(atom_array, AtomArrayStack):
-        return cast(AtomArrayStack, atom_array[:, mask])
+        return atom_array[:, mask]  # pyright: ignore[reportReturnType]
     else:
-        return cast(AtomArray, atom_array[mask])
+        return atom_array[mask]  # pyright: ignore[reportReturnType]
 
 
 def select_backbone(atom_array: AtomArray | AtomArrayStack) -> AtomArray | AtomArrayStack:
@@ -472,9 +472,9 @@ def select_backbone(atom_array: AtomArray | AtomArrayStack) -> AtomArray | AtomA
     mask = np.isin(atom_name, backbone_atoms)
 
     if isinstance(atom_array, AtomArrayStack):
-        return cast(AtomArrayStack, atom_array[:, mask])
+        return atom_array[:, mask]  # pyright: ignore[reportReturnType]
     else:
-        return cast(AtomArray, atom_array[mask])
+        return atom_array[mask]  # pyright: ignore[reportReturnType]
 
 
 def make_atom_id(arr: AtomArray | AtomArrayStack) -> np.ndarray:

--- a/src/sampleworks/utils/density_utils.py
+++ b/src/sampleworks/utils/density_utils.py
@@ -95,6 +95,11 @@ def compute_density_from_atomarray(
     - If xmap is provided: uses existing grid parameters (for RSCC evaluation)
     - If resolution is provided: creates synthetic grid (for density generation)
 
+    For :class:`~biotite.structure.AtomArrayStack` inputs, density is computed
+    independently for each model's coordinates and then summed. Occupancy
+    values are taken directly from the structure annotations (shared across
+    models in :class:`~biotite.structure.AtomArrayStack`).
+
     Parameters
     ----------
     atom_array : AtomArray | AtomArrayStack

--- a/src/sampleworks/utils/density_utils.py
+++ b/src/sampleworks/utils/density_utils.py
@@ -97,15 +97,15 @@ def compute_density_from_atomarray(
 
     Parameters
     ----------
-    atom_array
+    atom_array : AtomArray | AtomArrayStack
         Structure to compute density for
-    xmap
+    xmap : XMap | None
         Optional XMap with existing grid parameters. If provided, resolution is ignored.
-    resolution
+    resolution : float | None
         Map resolution in Angstroms. Used to create synthetic grid if xmap is not provided.
-    em_mode
+    em_mode : bool
         If True, use electron scattering factors. If False, use X-ray factors.
-    device
+    device : torch.device | None
         PyTorch device for computation. If None, will try to use GPU.
 
     Returns

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -698,6 +698,43 @@ def simple_atom_array_stack():
 
 
 @pytest.fixture(scope="module")
+def atom_array_stack_uniform_occ():
+    """AtomArrayStack with 2 models and occupancy 0.5"""
+
+    arrays = []
+    for i in range(2):
+        atom_array = AtomArray(3)
+        base_coords = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+        atom_array.coord = base_coords + i * 0.1
+        atom_array.set_annotation("chain_id", np.array(["A"] * 3))
+        atom_array.set_annotation("res_id", np.array([1, 2, 3]))
+        atom_array.set_annotation("element", np.array(["C", "C", "C"]))
+        atom_array.set_annotation("b_factor", np.array([20.0, 20.0, 20.0]))
+        atom_array.set_annotation("occupancy", np.array([0.5, 0.5, 0.5]))
+        arrays.append(atom_array)
+
+    return stack(arrays)
+
+
+@pytest.fixture(scope="module")
+def atom_array_stack_with_nan_coords():
+    """AtomArrayStack with 2 models where one model has a NaN coordinate."""
+
+    a1 = AtomArray(3)
+    a1.coord = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+    a1.set_annotation("chain_id", np.array(["A"] * 3))
+    a1.set_annotation("res_id", np.array([1, 2, 3]))
+    a1.set_annotation("element", np.array(["C", "C", "C"]))
+    a1.set_annotation("b_factor", np.array([20.0, 20.0, 20.0]))
+    a1.set_annotation("occupancy", np.array([0.5, 0.5, 0.5]))
+
+    a2 = a1.copy()
+    a2.coord = np.array([[0.0, 0.0, 0.0], [np.nan, 0.0, 0.0], [2.0, 0.0, 0.0]])
+
+    return stack([a1, a2])
+
+
+@pytest.fixture(scope="module")
 def basic_atom_array_altloc():
     """AtomArray with mixed altloc_ids."""
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI flags to remove hydrogens (excluding deuterium), waters, and ligands before density generation, plus optional saving of preprocessed structures; coordinate alignment applied when saving.
  * Utilities to filter atom sets to polymer or amino-acid atoms.

* **Improvements**
  * Occupancy handling validates inputs, forces custom mode when custom values supplied, and emits warnings on mismatches.

* **Bug Fixes**
  * Safer save operations with error handling and logged failures.

* **Tests**
  * Expanded tests for new utilities, filters, edge cases, and representation parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->