### PR TITLE
Align sampled structure to reference before computing maps in RSCC eval script; fixing tests.

### DIFF
--- a/scripts/eval/rscc_grid_search_script.py
+++ b/scripts/eval/rscc_grid_search_script.py
@@ -33,9 +33,12 @@ from sampleworks.eval.grid_search_eval_utils import parse_args, scan_grid_search
 from sampleworks.eval.metrics import rscc
 from sampleworks.eval.structure_utils import (
     get_asym_unit_from_structure,
+    get_reference_atomarraystack,
     get_reference_structure_coords,
 )
+from sampleworks.utils.atom_array_utils import filter_to_common_atoms
 from sampleworks.utils.density_utils import compute_density_from_atomarray
+from sampleworks.utils.frame_transforms import weighted_rigid_align_differentiable, apply_forward_transform
 
 
 # TODO consolidate eval script logic: https://github.com/diff-use/sampleworks/issues/93
@@ -163,6 +166,46 @@ def main(args: argparse.Namespace):
                     )
                     atom_array.set_annotation("b_factor", np.full(atom_array.coord.shape[-2], 20.0))
 
+                # TODO Check lines 166-205 _thoroughly_. They came from Claude.
+                # Align the refined structure to the reference structure
+                # 1. Get the reference structure path
+                ref_path, _ = get_reference_atomarraystack(protein_config, _exp.occ_a)
+                if ref_path is None:
+                    raise ValueError(f"Could not find reference structure for occupancy {_exp.occ_a}")
+
+                # 2. Load the reference structure with parse() to get only the first altloc
+                ref_structure = parse(ref_path, ccd_mirror_path=None)
+                ref_atom_array = get_asym_unit_from_structure(ref_structure)
+
+                # 3. Find the common atoms between the reference and the refined structure
+                ref_common, pred_common = filter_to_common_atoms(ref_atom_array, atom_array)
+
+                # 4. Align the refined structure to the reference using weighted_rigid_align_differentiable
+                # Convert to torch tensors with batch dimension
+                ref_coords_torch = torch.from_numpy(ref_common.coord).unsqueeze(0).float()  # [1, n_atoms, 3]
+                pred_coords_torch = torch.from_numpy(pred_common.coord).unsqueeze(0).float()  # [1, n_atoms, 3]
+
+                # Create uniform weights and mask for all common atoms
+                n_atoms = ref_coords_torch.shape[1]
+                weights = torch.ones(1, n_atoms)
+                mask = torch.ones(1, n_atoms)
+
+                # Align predicted to reference and get the transform
+                _, transform = weighted_rigid_align_differentiable(
+                    true_coords=pred_coords_torch,  # coords to align
+                    pred_coords=ref_coords_torch,   # target coords
+                    weights=weights,
+                    mask=mask,
+                    return_transforms=True,
+                    allow_gradients=False
+                )
+
+                # 5. Apply the transform to the entire refined structure (atom_array)
+                atom_array_coords_torch = torch.from_numpy(atom_array.coord).unsqueeze(0).float()
+                aligned_coords_torch = apply_forward_transform(atom_array_coords_torch, transform, rotation_only=False)
+                atom_array.coord = aligned_coords_torch.squeeze(0).numpy()
+
+                # Compute density from the aligned refined structure
                 _computed_density, _ = compute_density_from_atomarray(
                     atom_array, xmap=_base_xmap, em_mode=False, device=_device
                 )

--- a/scripts/eval/rscc_grid_search_script.py
+++ b/scripts/eval/rscc_grid_search_script.py
@@ -16,9 +16,12 @@ search results.
 
 import argparse
 import copy
+import pdb
+import sys
 import traceback
 from pathlib import Path
 
+import einx
 import numpy as np
 import pandas as pd
 import torch
@@ -36,9 +39,11 @@ from sampleworks.eval.structure_utils import (
     get_reference_atomarraystack,
     get_reference_structure_coords,
 )
-from sampleworks.utils.atom_array_utils import filter_to_common_atoms
+from sampleworks.utils.atom_array_utils import filter_to_common_atoms, \
+    remove_atoms_with_any_nan_coords
 from sampleworks.utils.density_utils import compute_density_from_atomarray
 from sampleworks.utils.frame_transforms import weighted_rigid_align_differentiable, apply_forward_transform
+from sampleworks.utils.framework_utils import match_batch
 
 
 # TODO consolidate eval script logic: https://github.com/diff-use/sampleworks/issues/93
@@ -92,6 +97,7 @@ def main(args: argparse.Namespace):
 
     results = []
     base_map_cache: dict[tuple[str, float, str], tuple[XMap, XMap]] = {}
+    ref_full_structure_cache: dict[tuple[str, float], object] = {}
     # TODO parallelize this loop? It uses GPU, so be careful.
     for _i, _exp in enumerate(all_experiments):
         if _exp.protein in protein_configs:
@@ -167,23 +173,42 @@ def main(args: argparse.Namespace):
                     atom_array.set_annotation("b_factor", np.full(atom_array.coord.shape[-2], 20.0))
 
                 # TODO Check lines 166-205 _thoroughly_. They came from Claude.
+                # Lines ~166-205 are to align the refined structure to the reference structure.
+                # so that the calculated maps are also aligned, for a correct RSCC calculation
+                #
                 # Align the refined structure to the reference structure
-                # 1. Get the reference structure path
-                ref_path, _ = get_reference_atomarraystack(protein_config, _exp.occ_a)
-                if ref_path is None:
-                    raise ValueError(f"Could not find reference structure for occupancy {_exp.occ_a}")
+                # 1. Get the reference structure path and load from cache if available
+                if (protein, _exp.occ_a) not in ref_full_structure_cache:
+                    ref_path = protein_config.get_reference_structure_path(_exp.occ_a)
+                    if ref_path is None:
+                        raise ValueError(f"Could not find reference structure for occupancy {_exp.occ_a}")
 
-                # 2. Load the reference structure with parse() to get only the first altloc
-                ref_structure = parse(ref_path, ccd_mirror_path=None)
-                ref_atom_array = get_asym_unit_from_structure(ref_structure)
+                    # 2. Load the reference structure with parse() to get only the first altloc
+                    ref_structure = parse(ref_path, ccd_mirror_path=None)
+                    ref_atom_array = get_asym_unit_from_structure(ref_structure)
+                    logger.info(
+                        f"Caching reference structure for {protein} occ_a={_exp.occ_a}"
+                    )
+                    ref_full_structure_cache[(protein, _exp.occ_a)] = ref_atom_array
+                else:
+                    ref_atom_array = ref_full_structure_cache[(protein, _exp.occ_a)]
 
-                # 3. Find the common atoms between the reference and the refined structure
+                # 3. Find the common atoms with non-nan coords between the reference
+                #    and the refined structure
+                ref_atom_array = remove_atoms_with_any_nan_coords(ref_atom_array)
+                atom_array = remove_atoms_with_any_nan_coords(atom_array)
                 ref_common, pred_common = filter_to_common_atoms(ref_atom_array, atom_array)
+
 
                 # 4. Align the refined structure to the reference using weighted_rigid_align_differentiable
                 # Convert to torch tensors with batch dimension
-                ref_coords_torch = torch.from_numpy(ref_common.coord).unsqueeze(0).float()  # [1, n_atoms, 3]
-                pred_coords_torch = torch.from_numpy(pred_common.coord).unsqueeze(0).float()  # [1, n_atoms, 3]
+                ref_coords_torch = torch.from_numpy(ref_common.coord).float()  # [1, n_atoms, 3]
+                pred_coords_torch = torch.from_numpy(pred_common.coord).float()  # [1, n_atoms, 3]
+
+                ref_coords_torch = match_batch(ref_coords_torch, pred_coords_torch.shape[0])
+                if len(ref_coords_torch.shape) != 3 or ref_coords_torch.shape[1] != pred_coords_torch.shape[1]:
+                    logger.error(f"Shape error: ref_coords_torch: {ref_coords_torch.shape}, pred_coords_torch: {pred_coords_torch.shape}")
+                    raise ValueError(f"ref_coords_torch and pred_coords_torch must have the same shape")
 
                 # Create uniform weights and mask for all common atoms
                 n_atoms = ref_coords_torch.shape[1]
@@ -192,8 +217,8 @@ def main(args: argparse.Namespace):
 
                 # Align predicted to reference and get the transform
                 _, transform = weighted_rigid_align_differentiable(
-                    true_coords=pred_coords_torch,  # coords to align
-                    pred_coords=ref_coords_torch,   # target coords
+                    true_coords=ref_coords_torch,  # coords to align
+                    pred_coords=pred_coords_torch,   # target coords
                     weights=weights,
                     mask=mask,
                     return_transforms=True,
@@ -201,9 +226,9 @@ def main(args: argparse.Namespace):
                 )
 
                 # 5. Apply the transform to the entire refined structure (atom_array)
-                atom_array_coords_torch = torch.from_numpy(atom_array.coord).unsqueeze(0).float()
+                atom_array_coords_torch = torch.from_numpy(atom_array.coord)
                 aligned_coords_torch = apply_forward_transform(atom_array_coords_torch, transform, rotation_only=False)
-                atom_array.coord = aligned_coords_torch.squeeze(0).numpy()
+                atom_array.coord = aligned_coords_torch.numpy()
 
                 # Compute density from the aligned refined structure
                 _computed_density, _ = compute_density_from_atomarray(

--- a/scripts/eval/rscc_grid_search_script.py
+++ b/scripts/eval/rscc_grid_search_script.py
@@ -18,7 +18,6 @@ import argparse
 import copy
 import traceback
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -26,6 +25,7 @@ import torch
 
 # Import local modules for density calculation
 from atomworks.io.parser import parse
+from biotite.structure import AtomArrayStack
 from loguru import logger
 from sampleworks.core.forward_models.xray.real_space_density_deps.qfit.volume import XMap
 from sampleworks.eval.constants import DEFAULT_SELECTION_PADDING
@@ -47,8 +47,6 @@ from sampleworks.utils.frame_transforms import (
 )
 from sampleworks.utils.framework_utils import match_batch
 
-if TYPE_CHECKING:
-    from biotite.structure import AtomArrayStack
 
 
 # TODO consolidate eval script logic: https://github.com/diff-use/sampleworks/issues/93
@@ -177,8 +175,7 @@ def main(args: argparse.Namespace):
                     )
                     atom_array.set_annotation("b_factor", np.full(atom_array.coord.shape[-2], 20.0))
 
-                # TODO Check lines 166-205 _thoroughly_. They came from Claude.
-                # Lines ~166-205 are to align the refined structure to the reference structure.
+                # Lines ~183-245 are to align the refined structure to the reference structure.
                 # so that the calculated maps are also aligned, for a correct RSCC calculation
                 #
                 # Align the refined structure to the reference structure

--- a/scripts/eval/rscc_grid_search_script.py
+++ b/scripts/eval/rscc_grid_search_script.py
@@ -16,12 +16,10 @@ search results.
 
 import argparse
 import copy
-import pdb
-import sys
 import traceback
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-import einx
 import numpy as np
 import pandas as pd
 import torch
@@ -36,14 +34,21 @@ from sampleworks.eval.grid_search_eval_utils import parse_args, scan_grid_search
 from sampleworks.eval.metrics import rscc
 from sampleworks.eval.structure_utils import (
     get_asym_unit_from_structure,
-    get_reference_atomarraystack,
     get_reference_structure_coords,
 )
-from sampleworks.utils.atom_array_utils import filter_to_common_atoms, \
-    remove_atoms_with_any_nan_coords
+from sampleworks.utils.atom_array_utils import (
+    filter_to_common_atoms,
+    remove_atoms_with_any_nan_coords,
+)
 from sampleworks.utils.density_utils import compute_density_from_atomarray
-from sampleworks.utils.frame_transforms import weighted_rigid_align_differentiable, apply_forward_transform
+from sampleworks.utils.frame_transforms import (
+    apply_forward_transform,
+    weighted_rigid_align_differentiable,
+)
 from sampleworks.utils.framework_utils import match_batch
+
+if TYPE_CHECKING:
+    from biotite.structure import AtomArrayStack
 
 
 # TODO consolidate eval script logic: https://github.com/diff-use/sampleworks/issues/93
@@ -97,7 +102,7 @@ def main(args: argparse.Namespace):
 
     results = []
     base_map_cache: dict[tuple[str, float, str], tuple[XMap, XMap]] = {}
-    ref_full_structure_cache: dict[tuple[str, float], object] = {}
+    ref_full_structure_cache: dict[tuple[str, float], AtomArrayStack] = {}
     # TODO parallelize this loop? It uses GPU, so be careful.
     for _i, _exp in enumerate(all_experiments):
         if _exp.protein in protein_configs:
@@ -181,14 +186,14 @@ def main(args: argparse.Namespace):
                 if (protein, _exp.occ_a) not in ref_full_structure_cache:
                     ref_path = protein_config.get_reference_structure_path(_exp.occ_a)
                     if ref_path is None:
-                        raise ValueError(f"Could not find reference structure for occupancy {_exp.occ_a}")
+                        raise ValueError(
+                            f"Could not find reference structure for occupancy {_exp.occ_a}"
+                        )
 
                     # 2. Load the reference structure with parse() to get only the first altloc
                     ref_structure = parse(ref_path, ccd_mirror_path=None)
                     ref_atom_array = get_asym_unit_from_structure(ref_structure)
-                    logger.info(
-                        f"Caching reference structure for {protein} occ_a={_exp.occ_a}"
-                    )
+                    logger.info(f"Caching reference structure for {protein} occ_a={_exp.occ_a}")
                     ref_full_structure_cache[(protein, _exp.occ_a)] = ref_atom_array
                 else:
                     ref_atom_array = ref_full_structure_cache[(protein, _exp.occ_a)]
@@ -199,16 +204,24 @@ def main(args: argparse.Namespace):
                 atom_array = remove_atoms_with_any_nan_coords(atom_array)
                 ref_common, pred_common = filter_to_common_atoms(ref_atom_array, atom_array)
 
-
-                # 4. Align the refined structure to the reference using weighted_rigid_align_differentiable
+                # 4. Align the refined structure to the reference
+                # using weighted_rigid_align_differentiable
                 # Convert to torch tensors with batch dimension
                 ref_coords_torch = torch.from_numpy(ref_common.coord).float()  # [1, n_atoms, 3]
                 pred_coords_torch = torch.from_numpy(pred_common.coord).float()  # [1, n_atoms, 3]
 
                 ref_coords_torch = match_batch(ref_coords_torch, pred_coords_torch.shape[0])
-                if len(ref_coords_torch.shape) != 3 or ref_coords_torch.shape[1] != pred_coords_torch.shape[1]:
-                    logger.error(f"Shape error: ref_coords_torch: {ref_coords_torch.shape}, pred_coords_torch: {pred_coords_torch.shape}")
-                    raise ValueError(f"ref_coords_torch and pred_coords_torch must have the same shape")
+                if (
+                    len(ref_coords_torch.shape) != 3
+                    or ref_coords_torch.shape[1] != pred_coords_torch.shape[1]
+                ):
+                    logger.error(
+                        f"Shape error: ref_coords_torch: {ref_coords_torch.shape}, "
+                        f"pred_coords_torch: {pred_coords_torch.shape}"
+                    )
+                    raise ValueError(
+                        "ref_coords_torch and pred_coords_torch must have the same shape"
+                    )
 
                 # Create uniform weights and mask for all common atoms
                 n_atoms = ref_coords_torch.shape[1]
@@ -218,16 +231,18 @@ def main(args: argparse.Namespace):
                 # Align predicted to reference and get the transform
                 _, transform = weighted_rigid_align_differentiable(
                     true_coords=pred_coords_torch,  # coords to align
-                    pred_coords=ref_coords_torch,   # target coords
+                    pred_coords=ref_coords_torch,  # target coords
                     weights=weights,
                     mask=mask,
                     return_transforms=True,
-                    allow_gradients=False
+                    allow_gradients=False,
                 )
 
                 # 5. Apply the transform to the entire refined structure (atom_array)
                 atom_array_coords_torch = torch.from_numpy(atom_array.coord)
-                aligned_coords_torch = apply_forward_transform(atom_array_coords_torch, transform, rotation_only=False)
+                aligned_coords_torch = apply_forward_transform(
+                    atom_array_coords_torch, transform, rotation_only=False
+                )
                 atom_array.coord = aligned_coords_torch.numpy()
 
                 # Compute density from the aligned refined structure
@@ -249,8 +264,8 @@ def main(args: argparse.Namespace):
 
                 # Calculate RSCC on extracted regions
                 # TODO: don't alter the input object _exp, just get a copy of it as a dict.
-                exp_result.rscc = rscc(_extracted_base, _extracted_computed)
-                exp_result.base_map_path = _base_map_path
+                exp_result["rscc"] = rscc(_extracted_base, _extracted_computed)
+                exp_result["base_map_path"] = _base_map_path
 
             except Exception as _e:
                 logger.error(f"ERROR processing {_exp.exp_dir}: {_e}")

--- a/scripts/eval/rscc_grid_search_script.py
+++ b/scripts/eval/rscc_grid_search_script.py
@@ -217,8 +217,8 @@ def main(args: argparse.Namespace):
 
                 # Align predicted to reference and get the transform
                 _, transform = weighted_rigid_align_differentiable(
-                    true_coords=ref_coords_torch,  # coords to align
-                    pred_coords=pred_coords_torch,   # target coords
+                    true_coords=pred_coords_torch,  # coords to align
+                    pred_coords=ref_coords_torch,   # target coords
                     weights=weights,
                     mask=mask,
                     return_transforms=True,

--- a/scripts/patch_input_cif_files.py
+++ b/scripts/patch_input_cif_files.py
@@ -13,6 +13,7 @@ from biotite.database.rcsb import fetch
 from biotite.structure.io.pdbx import CIFColumn, CIFFile, set_structure
 from loguru import logger
 
+from sampleworks.utils.atom_array_utils import remove_atoms_with_any_nan_coords
 
 SAMPLEWORKS_CACHE = Path("~/.sampleworks/rcsb").expanduser()
 
@@ -164,9 +165,7 @@ def patch_individual_cif_file(
 
     # remove any atoms with nan coordinates--these seem to come in because we sometimes use parse
     # (from AtomWorks) which creates them. Still, we'll do this here just in case.
-    # I do the flattening so that we remove all copies of an atom if it is missing in any structure
-    flat_coords = einx.rearrange("a b c -> b (a c)", asym_unit.coord)
-    asym_unit = asym_unit[:, ~np.isnan(flat_coords).any(axis=1)]
+    asym_unit = remove_atoms_with_any_nan_coords(asym_unit)
 
     # make sure entity ids match in atom_site and entity_poly
     if "entity_poly" in template.block:

--- a/scripts/patch_input_cif_files.py
+++ b/scripts/patch_input_cif_files.py
@@ -4,7 +4,6 @@ import re
 from argparse import ArgumentParser
 from pathlib import Path
 
-import einx
 import joblib
 import numpy as np
 from atomworks.io.transforms.atom_array import ensure_atom_array_stack
@@ -12,8 +11,8 @@ from atomworks.io.utils.io_utils import load_any
 from biotite.database.rcsb import fetch
 from biotite.structure.io.pdbx import CIFColumn, CIFFile, set_structure
 from loguru import logger
-
 from sampleworks.utils.atom_array_utils import remove_atoms_with_any_nan_coords
+
 
 SAMPLEWORKS_CACHE = Path("~/.sampleworks/rcsb").expanduser()
 
@@ -118,7 +117,7 @@ def patch_individual_cif_file(
         logger.warning(msg)
         return msg
 
-    # Get the offset for residue numbering in the reference structure    
+    # Get the offset for residue numbering in the reference structure
     try:
         reference_path = reference_dir / input_pdb_pattern.format(pdb_id=rcsb_id)
         # fetch only downloads the file if it isn't already present.
@@ -127,8 +126,8 @@ def patch_individual_cif_file(
         reference = load_any(reference_path)
         asym_unit = load_any(cif_file)
         asym_unit = ensure_atom_array_stack(asym_unit)
-    except Exception as e:
-        msg = f"Unable to read and parse either/both of {reference_path}, {cif_file}"
+    except Exception:
+        msg = f"Unable to read and parse either/both of {reference_path}, {cif_file}. "
         logger.warning(msg)
         return msg
 
@@ -141,7 +140,7 @@ def patch_individual_cif_file(
     # CodeRabbit improved this: we are now not chain agnostic, so we can handle multiple chains
     ref_keys = list(dict.fromkeys(zip(reference.chain_id.tolist(), reference.res_id.tolist())))
     cif_keys = list(dict.fromkeys(zip(asym_unit.chain_id.tolist(), asym_unit.res_id.tolist())))
-    
+
     # There should be a single, unique mapping between them. If not, something is wrong.
     if len(ref_keys) != len(cif_keys):
         msg = f"Residue numbers in {cif_path} cannot be mapped to those in {reference_path}"

--- a/src/sampleworks/core/rewards/real_space_density.py
+++ b/src/sampleworks/core/rewards/real_space_density.py
@@ -144,8 +144,8 @@ def extract_density_inputs_from_atomarray(
     if is_stack:
         if not np.all(valid_occupancy * n_models <= 1.0):
             logger.warning(
-                f"AtomArrayStack with {n_models} models: occupancy values sum to greater than 1 for"
-                "some atoms (max sum {valid_occupancy.max() * n_models:.4f}). This may lead to "
+                f"AtomArrayStack with {n_models} models: occupancy values sum to > 1 for "
+                f"some atoms (max sum {valid_occupancy.max() * n_models:.4f}). This may lead to "
                 "higher density values than expected under "
                 f"uniform model weighting (expected {1 / n_models:.4f}). Keeping "
                 "provided occupancies unchanged."

--- a/src/sampleworks/eval/grid_search_eval_utils.py
+++ b/src/sampleworks/eval/grid_search_eval_utils.py
@@ -94,7 +94,7 @@ def scan_grid_search_results(
         guidance_weight = None
         if params["guidance_weight"] is not None:
             guidance_weight = float(params["guidance_weight"])
-        gd_steps = int(params["gd_steps"]) if params["gd_steps"] else None
+        gd_steps = int(params["gd_steps"]) if params["gd_steps"] is not None else None
 
         # Validate parameters to satisfy pyright
         if (

--- a/src/sampleworks/eval/grid_search_eval_utils.py
+++ b/src/sampleworks/eval/grid_search_eval_utils.py
@@ -91,7 +91,9 @@ def scan_grid_search_results(
         method, model = get_method_and_model_name(model_dir.name)
 
         params = parse_experiment_dir(exp_dir)
-        guidance_weight = float(params["guidance_weight"]) if params["guidance_weight"] else None
+        guidance_weight = None
+        if params["guidance_weight"] is not None:
+            guidance_weight = float(params["guidance_weight"])
         gd_steps = int(params["gd_steps"]) if params["gd_steps"] else None
 
         # Validate parameters to satisfy pyright

--- a/src/sampleworks/eval/structure_utils.py
+++ b/src/sampleworks/eval/structure_utils.py
@@ -423,7 +423,7 @@ def get_asym_unit_from_structure(
     optionally specify the index of the AtomArray in the stack (e.g. for NMR models).
     """
     atom_array = structure["asym_unit"]
-    if atom_array_index and isinstance(atom_array, AtomArrayStack):
+    if atom_array_index is not None and isinstance(atom_array, AtomArrayStack):
         atom_array = atom_array.get_array(atom_array_index)
     if not isinstance(atom_array, (AtomArray, AtomArrayStack)):
         raise TypeError(f"Unexpected atom array type: {type(atom_array)}")

--- a/src/sampleworks/eval/structure_utils.py
+++ b/src/sampleworks/eval/structure_utils.py
@@ -2,7 +2,7 @@ import re
 import traceback
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, cast, overload
 
 import numpy as np
 import torch
@@ -401,6 +401,18 @@ def extract_selection_coordinates(
         )
 
     return selected_coords
+
+
+@overload
+def get_asym_unit_from_structure(
+    structure: dict, atom_array_index: None = None
+) ->  AtomArrayStack: ...
+
+
+@overload
+def get_asym_unit_from_structure(
+        structure: dict, atom_array_index: int
+) -> AtomArray: ...
 
 
 def get_asym_unit_from_structure(

--- a/src/sampleworks/utils/atom_array_utils.py
+++ b/src/sampleworks/utils/atom_array_utils.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast, Literal, overload
 
+import einx
 import numpy as np
 from atomworks.io.transforms.atom_array import ensure_atom_array_stack
 from atomworks.io.utils.io_utils import load_any
@@ -494,6 +495,30 @@ def remove_hydrogens(atom_array: AtomArray | AtomArrayStack) -> AtomArray | Atom
         return atom_array[:, mask]  # pyright: ignore[reportReturnType]
     else:
         return atom_array[mask]  # pyright: ignore[reportReturnType]
+
+
+@overload
+def remove_atoms_with_any_nan_coords(atom_array: AtomArrayStack) -> AtomArrayStack: ...
+
+
+@overload
+def remove_atoms_with_any_nan_coords(atom_array: AtomArray) -> AtomArray: ...
+
+
+def remove_atoms_with_any_nan_coords(
+        atom_array: AtomArray | AtomArrayStack
+) -> AtomArray | AtomArrayStack:
+    """
+    Remove atoms with any NaN coordinates in any structure from an AtomArray or AtomArrayStack.
+    """
+    if isinstance(atom_array, AtomArrayStack):
+        # Partially flatten the coords so that we remove any atom from all structures if any
+        # one of them has a NaN at that position.
+        flattened_coords = einx.rearrange("a b c -> b (a c)", atom_array.coord)
+    else:
+        flattened_coords = atom_array.coord
+
+    return atom_array[..., np.isfinite(flattened_coords).all(axis=1)]
 
 
 def select_backbone(atom_array: AtomArray | AtomArrayStack) -> AtomArray | AtomArrayStack:

--- a/src/sampleworks/utils/atom_array_utils.py
+++ b/src/sampleworks/utils/atom_array_utils.py
@@ -506,11 +506,14 @@ def remove_atoms_with_any_nan_coords(atom_array: AtomArray) -> AtomArray: ...
 
 
 def remove_atoms_with_any_nan_coords(
-        atom_array: AtomArray | AtomArrayStack
+    atom_array: AtomArray | AtomArrayStack,
 ) -> AtomArray | AtomArrayStack:
     """
     Remove atoms with any NaN coordinates in any structure from an AtomArray or AtomArrayStack.
     """
+    if not atom_array or not atom_array.shape[-1]:
+        raise ValueError("Cannot remove atoms from empty AtomArray|Stack")
+    
     if isinstance(atom_array, AtomArrayStack):
         # Partially flatten the coords so that we remove any atom from all structures if any
         # one of them has a NaN at that position.

--- a/src/sampleworks/utils/frame_transforms.py
+++ b/src/sampleworks/utils/frame_transforms.py
@@ -3,6 +3,7 @@ from types import ModuleType
 from typing import Literal, overload, TYPE_CHECKING
 
 import einx
+from loguru import logger
 
 
 if TYPE_CHECKING:
@@ -368,7 +369,11 @@ def weighted_rigid_align_differentiable(
 
     """
     backend_name, backend = get_backend(true_coords)
-    batch_size, num_points, dim = true_coords.shape
+    try:
+        batch_size, num_points, dim = true_coords.shape
+    except ValueError as e:
+        logger.error(f"Invalid shape for true_coords: {true_coords.shape}, must be b x n x d")
+        raise e
 
     if backend_name == "torch":
         weights_expanded = (mask * weights).unsqueeze(-1)  # type: ignore[union-attr]

--- a/tests/eval/test_structure_utils.py
+++ b/tests/eval/test_structure_utils.py
@@ -23,7 +23,7 @@ def mock_protein_config(tmp_path: Path) -> ProteinConfig:
     return ProteinConfig(
         protein="test",
         base_map_dir=tmp_path,
-        selection="chain A and resi 1-10",
+        selection=["chain A and resi 1-10", ],
         resolution=2.0,
         map_pattern="{occ_str}.ccp4",
         structure_pattern="{occ_str}.cif",
@@ -156,8 +156,13 @@ class TestExtractSelectionCoordinates:
 
     def test_no_matching_atoms_raises_runtime_error(self, basic_atom_array_multichain):
         """Test that no matching atoms raises RuntimeError."""
-        with pytest.raises(RuntimeError, match="No atoms matched selection"):
+        # Note: this is actually raising from get_mask_from_old_selection_string
+        with pytest.raises(ValueError, match="Selection 'chain Z' matched no atoms"):
             extract_selection_coordinates(basic_atom_array_multichain, "chain Z")
+
+        # this tests extract_selection_coordinates more directly
+        with pytest.raises(RuntimeError, match="No atoms matched selection"):
+            extract_selection_coordinates(basic_atom_array_multichain, "chain_id == 'Z'")
 
     def test_filters_nan_coordinates(self, caplog, atom_array_with_nan_coords):
         """Test that NaN coordinates are filtered out with warning."""
@@ -251,7 +256,7 @@ class TestGetReferenceAtomArrayStack:
         config = ProteinConfig(
             protein="test",
             base_map_dir=tmp_path,
-            selection="chain A",
+            selection=["chain A", ], 
             resolution=2.0,
             map_pattern="{occ_str}.ccp4",
             structure_pattern="{occ_str}.cif",
@@ -267,7 +272,7 @@ class TestGetReferenceAtomArrayStack:
         config = ProteinConfig(
             protein="6b8x",
             base_map_dir=resources_dir / "6b8x",
-            selection="chain A",
+            selection=["chain A", ],
             resolution=1.74,
             map_pattern="{occ_str}.ccp4",
             structure_pattern="6b8x_final.pdb",
@@ -282,39 +287,47 @@ class TestGetReferenceAtomArrayStack:
 class TestGetReferenceStructureCoords:
     """Tests for get_reference_structure_coords function."""
 
-    def test_returns_none_when_no_valid(self, mock_protein_config):
+    def test_returns_empty_dict_when_no_valid(self, mock_protein_config):
         """Test that no valid structures returns None."""
         coords = get_reference_structure_coords(mock_protein_config, "test", occ_list=(0.0, 1.0))
-        assert coords is None
+        assert isinstance(coords, dict)
+        assert len(coords) == 0
 
     def test_handles_exceptions_gracefully(self, tmp_path):
         """Test that exceptions are logged and function continues."""
         config = ProteinConfig(
             protein="test",
             base_map_dir=tmp_path,
-            selection="chain Z and resi 999",
+            selection=["chain Z and resi 999", ],
             resolution=2.0,
             map_pattern="{occ_str}.ccp4",
             structure_pattern="{occ_str}.cif",
         )
 
         coords = get_reference_structure_coords(config, "test", occ_list=(0.5,))
-        assert coords is None
+        assert isinstance(coords, dict)
+        assert len(coords) == 0
 
     def test_with_real_structure(self, resources_dir):
         """Test loading coords from real structure."""
+        selection_string = "chain A and resi 1-10"
         config = ProteinConfig(
             protein="6b8x",
             base_map_dir=resources_dir / "6b8x",
-            selection="chain A and resi 1-10",
+            selection=[selection_string, ],
             resolution=1.74,
             map_pattern="{occ_str}.ccp4",
             structure_pattern="6b8x_final.pdb",
         )
 
-        coords = get_reference_structure_coords(config, "6b8x", occ_list=(0.5,))
-        if coords is not None:
-            assert isinstance(coords, np.ndarray)
-            assert coords.ndim == 2
-            assert coords.shape[1] == 3
-            assert np.isfinite(coords).all()
+        coords_dict = get_reference_structure_coords(config, "6b8x", occ_list=(0.5,))
+        assert coords_dict is not None
+        assert isinstance(coords_dict, dict)
+        assert len(coords_dict) == 1
+        assert selection_string in coords_dict
+        
+        coords = coords_dict[selection_string]
+        assert isinstance(coords, np.ndarray)
+        assert coords.ndim == 2
+        assert coords.shape[1] == 3
+        assert np.isfinite(coords).all()

--- a/tests/eval/test_structure_utils.py
+++ b/tests/eval/test_structure_utils.py
@@ -288,7 +288,7 @@ class TestGetReferenceStructureCoords:
     """Tests for get_reference_structure_coords function."""
 
     def test_returns_empty_dict_when_no_valid(self, mock_protein_config):
-        """Test that no valid structures returns None."""
+        """Test that no valid structures returns and empty dictionary."""
         coords = get_reference_structure_coords(mock_protein_config, "test", occ_list=(0.0, 1.0))
         assert isinstance(coords, dict)
         assert len(coords) == 0

--- a/tests/utils/test_atom_array_utils.py
+++ b/tests/utils/test_atom_array_utils.py
@@ -928,7 +928,7 @@ class TestRemoveAtomsWithAnyNanCoords:
         atom_array = AtomArray(0)
         atom_array.coord = np.empty((0, 3))
 
-        with pytest.raises(ValueError, match="Cannot remove atoms from empty AtomArray|Stack"):
+        with pytest.raises(ValueError, match="Cannot remove atoms from empty AtomArray\|Stack"):
             remove_atoms_with_any_nan_coords(atom_array)
         
     def test_empty_atom_array_stack(self):
@@ -937,5 +937,5 @@ class TestRemoveAtomsWithAnyNanCoords:
         atom_array.coord = np.empty((0, 3))
         atom_stack = stack([atom_array, atom_array])
 
-        with pytest.raises(ValueError, match="Cannot remove atoms from empty AtomArray|Stack"):
+        with pytest.raises(ValueError, match="Cannot remove atoms from empty AtomArray\|Stack"):
             remove_atoms_with_any_nan_coords(atom_stack)

--- a/tests/utils/test_atom_array_utils.py
+++ b/tests/utils/test_atom_array_utils.py
@@ -12,6 +12,7 @@ from sampleworks.utils.atom_array_utils import (
     keep_amino_acids,
     keep_polymer,
     make_normalized_atom_id,
+    remove_atoms_with_any_nan_coords,
     remove_hydrogens,
     select_altloc,
 )
@@ -551,6 +552,7 @@ class TestFilterFunctionsIntegration:
         assert "H" not in elements
         assert "D" not in elements
         assert np.all(filter_polymer(polymer_first))
+
     def test_6b8x_altloc_a_vs_b_common_atoms(self, structure_6b8x_with_altlocs):
         """Full-array altloc A and B share atoms at positions with blank altlocs."""
         arr = structure_6b8x_with_altlocs
@@ -708,3 +710,232 @@ class TestReturnIndices:
             assert sub1.chain_id[i1] == sub2.chain_id[i2]
             assert sub1.res_id[i1] == sub2.res_id[i2]
             assert sub1.atom_name[i1] == sub2.atom_name[i2]
+
+
+class TestRemoveAtomsWithAnyNanCoords:
+    """Tests for remove_atoms_with_any_nan_coords function."""
+
+    def test_atom_array_all_finite(self):
+        """Test AtomArray with all finite coordinates - should return unchanged."""
+        atom_array = AtomArray(5)
+        atom_array.coord = np.array(
+            [
+                [1.0, 2.0, 3.0],
+                [4.0, 5.0, 6.0],
+                [7.0, 8.0, 9.0],
+                [10.0, 11.0, 12.0],
+                [13.0, 14.0, 15.0],
+            ]
+        )
+        atom_array.set_annotation("chain_id", np.array(["A"] * 5))
+        atom_array.set_annotation("res_id", np.array([1, 2, 3, 4, 5]))
+        atom_array.set_annotation("atom_name", np.array(["CA", "CA", "CA", "CA", "CA"]))
+
+        result = remove_atoms_with_any_nan_coords(atom_array)
+
+        assert len(result) == 5
+        np.testing.assert_array_equal(result.coord, atom_array.coord)
+
+    def test_atom_array_with_nan_coords(self):
+        """Test AtomArray with some NaN coordinates - should remove those atoms."""
+        atom_array = AtomArray(5)
+        atom_array.coord = np.array(
+            [
+                [1.0, 2.0, 3.0],
+                [4.0, np.nan, 6.0],  # Has NaN in y coordinate
+                [7.0, 8.0, 9.0],
+                [np.nan, 11.0, 12.0],  # Has NaN in x coordinate
+                [13.0, 14.0, 15.0],
+            ]
+        )
+        atom_array.set_annotation("chain_id", np.array(["A"] * 5))
+        atom_array.set_annotation("res_id", np.array([1, 2, 3, 4, 5]))
+        atom_array.set_annotation("atom_name", np.array(["CA", "CB", "CG", "CD", "CE"]))
+
+        result = remove_atoms_with_any_nan_coords(atom_array)
+
+        assert len(result) == 3
+        assert list(cast(np.ndarray, result.res_id)) == [1, 3, 5]
+        assert list(cast(np.ndarray, result.atom_name)) == ["CA", "CG", "CE"]
+        assert np.isfinite(result.coord).all()
+
+    def test_atom_array_with_inf_coords(self):
+        """Test AtomArray with infinite coordinates - should remove those atoms."""
+        atom_array = AtomArray(4)
+        atom_array.coord = np.array(
+            [
+                [1.0, 2.0, 3.0],
+                [4.0, np.inf, 6.0],  # Has inf in y coordinate
+                [7.0, 8.0, 9.0],
+                [10.0, -np.inf, 12.0],  # Has -inf in y coordinate
+            ]
+        )
+        atom_array.set_annotation("chain_id", np.array(["A"] * 4))
+        atom_array.set_annotation("res_id", np.array([1, 2, 3, 4]))
+        atom_array.set_annotation("atom_name", np.array(["CA", "CB", "CG", "CD"]))
+
+        result = remove_atoms_with_any_nan_coords(atom_array)
+
+        assert len(result) == 2
+        assert list(cast(np.ndarray, result.res_id)) == [1, 3]
+        assert np.isfinite(result.coord).all()
+
+    def test_atom_array_all_nan(self):
+        """Test AtomArray where all atoms have NaN - should return empty array."""
+        atom_array = AtomArray(3)
+        atom_array.coord = np.array(
+            [
+                [np.nan, 2.0, 3.0],
+                [4.0, np.nan, 6.0],
+                [7.0, 8.0, np.nan],
+            ]
+        )
+        atom_array.set_annotation("chain_id", np.array(["A"] * 3))
+
+        result = remove_atoms_with_any_nan_coords(atom_array)
+
+        assert len(result) == 0
+
+    def test_atom_array_stack_all_finite(self):
+        """Test AtomArrayStack with all finite coordinates."""
+        # Create 2 models with 4 atoms each
+        coords = np.array(
+            [
+                [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
+                [[1.1, 2.1, 3.1], [4.1, 5.1, 6.1], [7.1, 8.1, 9.1], [10.1, 11.1, 12.1]],
+            ]
+        )
+
+        atom_array1 = AtomArray(4)
+        atom_array1.coord = coords[0]
+        atom_array1.set_annotation("chain_id", np.array(["A"] * 4))
+        atom_array1.set_annotation("res_id", np.array([1, 2, 3, 4]))
+        atom_array1.set_annotation("atom_name", np.array(["CA", "CB", "CG", "CD"]))
+
+        atom_array2 = AtomArray(4)
+        atom_array2.coord = coords[1]
+        atom_array2.set_annotation("chain_id", np.array(["A"] * 4))
+        atom_array2.set_annotation("res_id", np.array([1, 2, 3, 4]))
+        atom_array2.set_annotation("atom_name", np.array(["CA", "CB", "CG", "CD"]))
+
+        atom_stack = stack([atom_array1, atom_array2])
+        result = remove_atoms_with_any_nan_coords(atom_stack)
+
+        assert isinstance(result, AtomArrayStack)
+        assert result.stack_depth() == 2
+        assert result.array_length() == 4
+        # there's some float issue here, so we use almost equal.
+        np.testing.assert_array_almost_equal(result.coord, coords)
+
+    def test_atom_array_stack_nan_in_one_model(self):
+        """Test AtomArrayStack where one model has NaN - should remove that atom from all models."""
+        # Create 2 models, first has NaN in atom index 1
+        coords = np.array(
+            [
+                [[1.0, 2.0, 3.0], [4.0, np.nan, 6.0], [7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
+                [[1.1, 2.1, 3.1], [4.1, 5.1, 6.1], [7.1, 8.1, 9.1], [10.1, 11.1, 12.1]],
+            ]
+        )
+
+        atom_array1 = AtomArray(4)
+        atom_array1.coord = coords[0]
+        atom_array1.set_annotation("chain_id", np.array(["A"] * 4))
+        atom_array1.set_annotation("res_id", np.array([1, 2, 3, 4]))
+        atom_array1.set_annotation("atom_name", np.array(["CA", "CB", "CG", "CD"]))
+
+        atom_array2 = AtomArray(4)
+        atom_array2.coord = coords[1]
+        atom_array2.set_annotation("chain_id", np.array(["A"] * 4))
+        atom_array2.set_annotation("res_id", np.array([1, 2, 3, 4]))
+        atom_array2.set_annotation("atom_name", np.array(["CA", "CB", "CG", "CD"]))
+
+        atom_stack = stack([atom_array1, atom_array2])
+        result = remove_atoms_with_any_nan_coords(atom_stack)
+
+        assert isinstance(result, AtomArrayStack)
+        assert result.stack_depth() == 2
+        assert result.array_length() == 3  # Atom at index 1 removed from all models
+        assert list(cast(np.ndarray, result[0].res_id)) == [1, 3, 4]
+        assert list(cast(np.ndarray, result[1].res_id)) == [1, 3, 4]
+        assert np.isfinite(result.coord).all()
+
+    def test_atom_array_stack_nan_in_different_models(self):
+        """Test AtomArrayStack where different models have NaN in different atoms."""
+        # Model 1 has NaN in atom 1, Model 2 has NaN in atom 2
+        coords = np.array(
+            [
+                [[1.0, 2.0, 3.0], [4.0, np.nan, 6.0], [7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
+                [[1.1, 2.1, 3.1], [4.1, 5.1, 6.1], [7.1, np.nan, 9.1], [10.1, 11.1, 12.1]],
+            ]
+        )
+
+        atom_array1 = AtomArray(4)
+        atom_array1.coord = coords[0]
+        atom_array1.set_annotation("chain_id", np.array(["A"] * 4))
+        atom_array1.set_annotation("res_id", np.array([1, 2, 3, 4]))
+        atom_array1.set_annotation("atom_name", np.array(["CA", "CB", "CG", "CD"]))
+
+        atom_array2 = AtomArray(4)
+        atom_array2.coord = coords[1]
+        atom_array2.set_annotation("chain_id", np.array(["A"] * 4))
+        atom_array2.set_annotation("res_id", np.array([1, 2, 3, 4]))
+        atom_array2.set_annotation("atom_name", np.array(["CA", "CB", "CG", "CD"]))
+
+        atom_stack = stack([atom_array1, atom_array2])
+        result = remove_atoms_with_any_nan_coords(atom_stack)
+
+        # Both atoms 1 and 2 should be removed from all models
+        assert isinstance(result, AtomArrayStack)
+        assert result.stack_depth() == 2
+        assert result.array_length() == 2
+        assert list(cast(np.ndarray, result[0].res_id)) == [1, 4]
+        assert list(cast(np.ndarray, result[1].res_id)) == [1, 4]
+        assert np.isfinite(result.coord).all()
+
+    def test_atom_array_stack_preserves_annotations(self):
+        """Test that annotations are preserved after filtering."""
+        coords = np.array(
+            [
+                [[1.0, 2.0, 3.0], [4.0, np.nan, 6.0], [7.0, 8.0, 9.0]],
+                [[1.1, 2.1, 3.1], [4.1, 5.1, 6.1], [7.1, 8.1, 9.1]],
+            ]
+        )
+
+        atom_array1 = AtomArray(3)
+        atom_array1.coord = coords[0]
+        atom_array1.set_annotation("chain_id", np.array(["A", "A", "B"]))
+        atom_array1.set_annotation("res_id", np.array([1, 2, 3]))
+        atom_array1.set_annotation("atom_name", np.array(["CA", "CB", "CG"]))
+        atom_array1.set_annotation("res_name", np.array(["ALA", "VAL", "LEU"]))
+
+        atom_array2 = AtomArray(3)
+        atom_array2.coord = coords[1]
+        atom_array2.set_annotation("chain_id", np.array(["A", "A", "B"]))
+        atom_array2.set_annotation("res_id", np.array([1, 2, 3]))
+        atom_array2.set_annotation("atom_name", np.array(["CA", "CB", "CG"]))
+        atom_array2.set_annotation("res_name", np.array(["ALA", "VAL", "LEU"]))
+
+        atom_stack = stack([atom_array1, atom_array2])
+        result = remove_atoms_with_any_nan_coords(atom_stack)
+
+        assert list(cast(np.ndarray, result[0].chain_id)) == ["A", "B"]
+        assert list(cast(np.ndarray, result[0].res_id)) == [1, 3]
+        assert list(cast(np.ndarray, result[0].atom_name)) == ["CA", "CG"]
+        assert list(cast(np.ndarray, result[0].res_name)) == ["ALA", "LEU"]
+
+    def test_empty_atom_array(self):
+        """Test with empty AtomArray."""
+        atom_array = AtomArray(0)
+        atom_array.coord = np.empty((0, 3))
+
+        with pytest.raises(ValueError, match="Cannot remove atoms from empty AtomArray|Stack"):
+            remove_atoms_with_any_nan_coords(atom_array)
+        
+    def test_empty_atom_array_stack(self):
+        """Test with empty AtomArrayStack."""
+        atom_array = AtomArray(0)
+        atom_array.coord = np.empty((0, 3))
+        atom_stack = stack([atom_array, atom_array])
+
+        with pytest.raises(ValueError, match="Cannot remove atoms from empty AtomArray|Stack"):
+            remove_atoms_with_any_nan_coords(atom_stack)


### PR DESCRIPTION
This PR adds a step before computing density maps from the sampled structure to ensure it is aligned with the reference structure, using the same alignment methods used in guidance. I have added some tests for a new method that turned out to be necessary for filtering NaNs from structures. 

Also caught some broken tests from a previous PR and am fixing those. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility to remove atoms with invalid (NaN/Inf) coordinates.
  * Refined alignment of refined structures to reference structures before RSCC evaluation.

* **Bug Fixes**
  * Preserve zero values when parsing guidance parameters.
  * Improved handling of invalid/mismatched coordinates and missing reference data.

* **Refactor**
  * Strengthened type signatures and added safer shape/validation checks.

* **Tests**
  * Added comprehensive tests for coordinate-validation utilities and related behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->