### PR TITLE
Write out job metadata to a file in the same directory as refined.cif

### DIFF
--- a/src/sampleworks/utils/guidance_script_utils.py
+++ b/src/sampleworks/utils/guidance_script_utils.py
@@ -388,6 +388,9 @@ def run_guidance(
     log_path = getattr(args, "log_path", None) or os.path.join(args.output_dir, "run.log")
     os.makedirs(os.path.dirname(log_path) or ".", exist_ok=True)
 
+    # just in case log_path does not go to args.output_dir, make sure the latter exists
+    os.makedirs(args.output_dir, exist_ok=True)
+
     # separate logs for each guidance run
     handle = logger.add(
         log_path, level="INFO", filter=lambda rec: rec["extra"].get("special", False) is True


### PR DESCRIPTION
Behold, the world's simplest PR. Just write out some metadata so it will be easier to process the results of our occupancy sweeps.

This starts to address https://github.com/diff-use/sampleworks/issues/121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guidance jobs now write a job_metadata.json file into each job's output directory after completion.
  * Output directories are now created automatically as needed before jobs run.
* **Bug Fixes**
  * Improved reliability of per-job metadata persistence and isolation so results and metadata are consistently saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->