### PR TITLE
Bake RF3 and Protenix checkpoints into Docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,6 +219,7 @@ CLAUDE.local.md
 
 # Model checkpoints
 release_data/
+checkpoints/
 
 # Large results from runs
 grid_search_results/

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,15 @@
 #   docker run --gpus all -it sampleworks bash
 #
 # Baked-in checkpoints:
-#   /checkpoints/boltz1_conf.ckpt  - Boltz1 model
-#   /checkpoints/boltz2_conf.ckpt  - Boltz2 model  
-#   /checkpoints/ccd.pkl           - Chemical Component Dictionary (required for Boltz)
+#   /checkpoints/boltz1_conf.ckpt                   - Boltz1 model (downloaded from HuggingFace)
+#   /checkpoints/boltz2_conf.ckpt                   - Boltz2 model (downloaded from HuggingFace)
+#   /checkpoints/ccd.pkl                             - Chemical Component Dictionary (required for Boltz)
+#   /checkpoints/rf3_foundry_01_24_latest.ckpt       - RF3 model (copied from build context)
+#   /checkpoints/protenix_base_default_v0.5.0.pt     - Protenix model (copied from build context)
+#
+# Before building, copy RF3 and Protenix checkpoints into the build context:
+#   cp /mnt/diffuse-private/raw/checkpoints/rf3_foundry_01_24_latest.ckpt checkpoints/
+#   cp /mnt/diffuse-private/raw/checkpoints/protenix_base_default_v0.5.0.pt checkpoints/
 
 # ============================================================================
 # Base stage: CUDA + Pixi + common system dependencies
@@ -107,6 +113,8 @@ print('CUDA extensions compiled successfully')" || echo "CUDA extension pre-comp
 # ============================================================================
 # Download and bake in model checkpoints
 # ============================================================================
+
+# Download Boltz checkpoints from HuggingFace (publicly available)
 RUN mkdir -p /checkpoints && \
     echo "Downloading Boltz1 checkpoint..." && \
     curl -L -o /checkpoints/boltz1_conf.ckpt \
@@ -121,13 +129,22 @@ RUN mkdir -p /checkpoints && \
     curl -L -o /checkpoints/mols.tar \
         "https://huggingface.co/boltz-community/boltz-2/resolve/main/mols.tar" && \
     cd /checkpoints && tar -xf mols.tar && rm mols.tar && \
-    echo "All checkpoints downloaded!" && \
+    echo "Boltz checkpoints downloaded!" && \
     ls -lh /checkpoints/
+
+# Copy RF3 and Protenix checkpoints from build context
+# These must be placed in checkpoints/ before building:
+#   cp /mnt/diffuse-private/raw/checkpoints/rf3_foundry_01_24_latest.ckpt checkpoints/
+#   cp /mnt/diffuse-private/raw/checkpoints/protenix_base_default_v0.5.0.pt checkpoints/
+COPY checkpoints/rf3_foundry_01_24_latest.ckpt /checkpoints/rf3_foundry_01_24_latest.ckpt
+COPY checkpoints/protenix_base_default_v0.5.0.pt /checkpoints/protenix_base_default_v0.5.0.pt
 
 # Set default checkpoint paths via environment variables
 ENV BOLTZ1_CHECKPOINT=/checkpoints/boltz1_conf.ckpt \
     BOLTZ2_CHECKPOINT=/checkpoints/boltz2_conf.ckpt \
-    CCD_PATH=/checkpoints/ccd.pkl
+    CCD_PATH=/checkpoints/ccd.pkl \
+    RF3_CHECKPOINT=/checkpoints/rf3_foundry_01_24_latest.ckpt \
+    PROTENIX_CHECKPOINT=/checkpoints/protenix_base_default_v0.5.0.pt
 
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["--help"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -144,9 +144,11 @@ GRID SEARCH ARGUMENTS (run_grid_search.py):
 
 BAKED-IN CHECKPOINTS:
     The following checkpoints are pre-installed in the image:
-      /checkpoints/boltz1_conf.ckpt  - Boltz1 model (~3.5GB)
-      /checkpoints/boltz2_conf.ckpt  - Boltz2 model (~2.3GB)
-      /checkpoints/ccd.pkl           - Chemical Component Dictionary (~345MB)
+      /checkpoints/boltz1_conf.ckpt                   - Boltz1 model (~3.5GB)
+      /checkpoints/boltz2_conf.ckpt                   - Boltz2 model (~2.3GB)
+      /checkpoints/ccd.pkl                             - Chemical Component Dictionary (~345MB)
+      /checkpoints/rf3_foundry_01_24_latest.ckpt       - RF3 model (~2.9GB)
+      /checkpoints/protenix_base_default_v0.5.0.pt     - Protenix model (~1.4GB)
 
     FK steering options:
       --num-gd-steps "N M..."     Space-separated GD steps (FK steering only)

--- a/run_grid_search.py
+++ b/run_grid_search.py
@@ -485,9 +485,9 @@ def parse_args() -> argparse.Namespace:
         "--rf3-checkpoint",
         default=os.environ.get(
             "RF3_CHECKPOINT",
-            os.path.expanduser("~/.foundry/checkpoints/rf3_foundry_01_24_latest_remapped.ckpt"),
+            os.path.expanduser("~/.foundry/checkpoints/rf3_foundry_01_24_latest.ckpt"),
         ),
-        help="RF3 checkpoint path",
+        help="RF3 checkpoint path (default: $RF3_CHECKPOINT or ~/.foundry/checkpoints/rf3_foundry_01_24_latest.ckpt)",
     )
     parser.add_argument(
         "--methods",

--- a/src/sampleworks/utils/guidance_script_arguments.py
+++ b/src/sampleworks/utils/guidance_script_arguments.py
@@ -222,7 +222,7 @@ def add_rf3_specific_args(parser: argparse.ArgumentParser | GuidanceConfig):
     parser.add_argument(
         "--model-checkpoint",
         type=str,
-        default="~/.foundry/checkpoints/rf3_foundry_01_24_latest_remapped.ckpt",
+        default="~/.foundry/checkpoints/rf3_foundry_01_24_latest.ckpt",
         help="Path to RF3 checkpoint",
     )
     parser.add_argument(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -601,7 +601,7 @@ def protenix_wrapper(protenix_checkpoint_path: Path, device: torch.device):
 def rf3_checkpoint_path() -> Path:
     if not RF3_AVAILABLE:
         pytest.skip("RF3 dependencies not installed in this environment")
-    path = Path("~/.foundry/checkpoints/rf3_foundry_01_24_latest_remapped.ckpt").expanduser()
+    path = Path("~/.foundry/checkpoints/rf3_foundry_01_24_latest.ckpt").expanduser()
     if not path.exists():
         pytest.skip(f"RF3 checkpoint not found at {path}")
     return path


### PR DESCRIPTION
## Summary

- **Bake RF3 + Protenix checkpoints** into the Docker image via `COPY` from a `checkpoints/` build context directory, alongside the existing Boltz checkpoints downloaded from HuggingFace. Sets `RF3_CHECKPOINT` and `PROTENIX_CHECKPOINT` env vars so `run_grid_search.py` resolves them automatically.
- **Fix RF3 default checkpoint filename** from the non-existent `rf3_foundry_01_24_latest_remapped.ckpt` to the actual filename `rf3_foundry_01_24_latest.ckpt` across `run_grid_search.py`, `guidance_script_arguments.py`, and `tests/conftest.py`.
- **Add `checkpoints/` to `.gitignore`** to prevent multi-GB files from being committed.

## Build instructions

Before building, copy the checkpoints into the build context:
```bash
mkdir -p checkpoints
cp /mnt/diffuse-private/raw/checkpoints/rf3_foundry_01_24_latest.ckpt checkpoints/
cp /mnt/diffuse-private/raw/checkpoints/protenix_base_default_v0.5.0.pt checkpoints/
docker build -t sampleworks:latest .
```

## Testing

Verified on the remote server (147.185.40.239):
- Docker image builds successfully with all 5 checkpoints baked in
- `--methods "X-RAY DIFFRACTION"` parses correctly through `run_model` -> Docker -> entrypoint -> argparse
- RF3 checkpoint found at `/checkpoints/rf3_foundry_01_24_latest.ckpt` (2.8 GB)
- Protenix checkpoint found at `/checkpoints/protenix_base_default_v0.5.0.pt` (1.4 GB)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for additional protein structure prediction models including Boltz1, Boltz2, CCD, RF3, and Protenix.
  * Updated checkpoint path configuration across the application for improved model handling.
  * Enhanced Docker setup to include and manage multiple model checkpoints.
  * Updated ignore patterns for build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->