### PR TITLE
fix: use checkpoints base image from Docker Hub for CI builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -55,3 +55,6 @@ results/
 
 # Hatch alternative config (not needed in container)
 pyproject-hatch.toml
+
+# Checkpoint files (baked in via COPY --from=diffuseproject/sampleworks-checkpoints:latest)
+checkpoints/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,10 @@
 name: Build and Push Docker Images
 
+# CI builds pull all model checkpoints (~10 GB) from Docker Hub automatically via:
+#   COPY --from=diffuseproject/sampleworks-checkpoints:latest /checkpoints/ /checkpoints/
+# No checkpoint files are needed on the CI runner. The checkpoints base image is
+# pre-built and pushed from the GPU server. See Dockerfile comments for details.
+
 on:
   push:
     branches: [main]
@@ -9,6 +14,7 @@ on:
       - 'src/**'
       - 'scripts/**'
       - 'Dockerfile'
+      - 'docker-entrypoint.sh'
       - '.github/workflows/docker.yml'
   workflow_dispatch:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,13 @@
 # Build:
 #   docker build -t sampleworks .
 #
+# CI builds pull checkpoints automatically from Docker Hub via:
+#   COPY --from=diffuseproject/sampleworks-checkpoints:latest
+# No checkpoint files are needed in the build context or on the CI runner.
+#
+# To rebuild the checkpoints base image (only needed when checkpoints change):
+#   See /data/users/diffuse/checkpoint-build/ on the GPU server
+#
 # Run examples:
 #   # Show help
 #   docker run sampleworks --help
@@ -40,16 +47,13 @@
 #   # Interactive shell
 #   docker run --gpus all -it sampleworks bash
 #
-# Baked-in checkpoints:
-#   /checkpoints/boltz1_conf.ckpt                   - Boltz1 model (downloaded from HuggingFace)
-#   /checkpoints/boltz2_conf.ckpt                   - Boltz2 model (downloaded from HuggingFace)
+# Baked-in checkpoints (from diffuseproject/sampleworks-checkpoints:latest):
+#   /checkpoints/boltz1_conf.ckpt                   - Boltz1 model
+#   /checkpoints/boltz2_conf.ckpt                   - Boltz2 model
 #   /checkpoints/ccd.pkl                             - Chemical Component Dictionary (required for Boltz)
-#   /checkpoints/rf3_foundry_01_24_latest.ckpt       - RF3 model (copied from build context)
-#   /checkpoints/protenix_base_default_v0.5.0.pt     - Protenix model (copied from build context)
-#
-# Before building, copy RF3 and Protenix checkpoints into the build context:
-#   cp /mnt/diffuse-private/raw/checkpoints/rf3_foundry_01_24_latest.ckpt checkpoints/
-#   cp /mnt/diffuse-private/raw/checkpoints/protenix_base_default_v0.5.0.pt checkpoints/
+#   /checkpoints/mols/                               - Boltz2 molecules data
+#   /checkpoints/rf3_foundry_01_24_latest.ckpt       - RF3 model
+#   /checkpoints/protenix_base_default_v0.5.0.pt     - Protenix model
 
 # ============================================================================
 # Base stage: CUDA + Pixi + common system dependencies
@@ -111,33 +115,12 @@ from sampleworks.core.forward_models.xray.real_space_density_deps.ops import dil
 print('CUDA extensions compiled successfully')" || echo "CUDA extension pre-compilation skipped (no GPU during build)"
 
 # ============================================================================
-# Download and bake in model checkpoints
+# Bake in model checkpoints from pre-built base image on Docker Hub
+# This image contains: boltz1, boltz2, ccd, mols/, rf3, protenix checkpoints
+# Rebuild with: docker build -t diffuseproject/sampleworks-checkpoints:latest
+#               docker push diffuseproject/sampleworks-checkpoints:latest
 # ============================================================================
-
-# Download Boltz checkpoints from HuggingFace (publicly available)
-RUN mkdir -p /checkpoints && \
-    echo "Downloading Boltz1 checkpoint..." && \
-    curl -L -o /checkpoints/boltz1_conf.ckpt \
-        "https://huggingface.co/boltz-community/boltz-1/resolve/main/boltz1_conf.ckpt" && \
-    echo "Downloading Boltz2 checkpoint..." && \
-    curl -L -o /checkpoints/boltz2_conf.ckpt \
-        "https://huggingface.co/boltz-community/boltz-2/resolve/main/boltz2_conf.ckpt" && \
-    echo "Downloading CCD (Chemical Component Dictionary)..." && \
-    curl -L -o /checkpoints/ccd.pkl \
-        "https://huggingface.co/boltz-community/boltz-1/resolve/main/ccd.pkl" && \
-    echo "Downloading Boltz2 molecules data..." && \
-    curl -L -o /checkpoints/mols.tar \
-        "https://huggingface.co/boltz-community/boltz-2/resolve/main/mols.tar" && \
-    cd /checkpoints && tar -xf mols.tar && rm mols.tar && \
-    echo "Boltz checkpoints downloaded!" && \
-    ls -lh /checkpoints/
-
-# Copy RF3 and Protenix checkpoints from build context
-# These must be placed in checkpoints/ before building:
-#   cp /mnt/diffuse-private/raw/checkpoints/rf3_foundry_01_24_latest.ckpt checkpoints/
-#   cp /mnt/diffuse-private/raw/checkpoints/protenix_base_default_v0.5.0.pt checkpoints/
-COPY checkpoints/rf3_foundry_01_24_latest.ckpt /checkpoints/rf3_foundry_01_24_latest.ckpt
-COPY checkpoints/protenix_base_default_v0.5.0.pt /checkpoints/protenix_base_default_v0.5.0.pt
+COPY --from=diffuseproject/sampleworks-checkpoints:latest /checkpoints/ /checkpoints/
 
 # Set default checkpoint paths via environment variables
 ENV BOLTZ1_CHECKPOINT=/checkpoints/boltz1_conf.ckpt \

--- a/run_all_models.sh
+++ b/run_all_models.sh
@@ -49,7 +49,7 @@ run_model() {
         --gpus "\"device=$gpus\"" \
         -v /mnt/diffuse-private:/mnt/diffuse-private:ro \
         -v "$RESULTS_DIR:/data/results" \
-        $IMAGE \
+        "$IMAGE" \
         -e "$env" run_grid_search.py \
         --proteins "$DATA_DIR/proteins.csv" \
         --models "$model" \

--- a/run_all_models.sh
+++ b/run_all_models.sh
@@ -12,6 +12,8 @@ set -e
 # Configuration - uses absolute path to data
 DATA_DIR="/mnt/diffuse-private/raw/sampleworks/initial_dataset_40"
 RESULTS_DIR="${RESULTS_DIR:-$HOME/sampleworks-exp/grid_search_results}"
+# Docker image to use (override with IMAGE env var)
+IMAGE="${IMAGE:-diffuseproject/sampleworks:latest}"
 
 # Create output directory
 mkdir -p "$RESULTS_DIR"
@@ -24,6 +26,7 @@ echo "Starting all model grid searches"
 echo "Models: boltz1, boltz2, protenix, rf3"
 echo "Data: $DATA_DIR"
 echo "Results: $RESULTS_DIR"
+echo "Image: $IMAGE"
 echo "Checkpoints: BAKED INTO IMAGE"
 echo "=========================================="
 
@@ -46,7 +49,7 @@ run_model() {
         --gpus "\"device=$gpus\"" \
         -v /mnt/diffuse-private:/mnt/diffuse-private:ro \
         -v "$RESULTS_DIR:/data/results" \
-        sampleworks:latest \
+        $IMAGE \
         -e "$env" run_grid_search.py \
         --proteins "$DATA_DIR/proteins.csv" \
         --models "$model" \


### PR DESCRIPTION
## Summary

- **Replace curl downloads + build-context COPY** in the Dockerfile with a single `COPY --from=diffuseproject/sampleworks-checkpoints:latest /checkpoints/ /checkpoints/` so that CI (`ubuntu-latest`) can build without needing checkpoint files locally (~10 GB). Docker automatically pulls the pre-built checkpoints layer from Docker Hub during the build.
- **Add `checkpoints/`** to `.dockerignore` to prevent accidental inclusion in build context
- **Add `docker-entrypoint.sh`** to CI workflow path triggers so changes to the entrypoint trigger a rebuild
- **Add CI comment** to `docker.yml` explaining the checkpoints base image pattern
- **Make `run_all_models.sh`** use a configurable `IMAGE` env var (default: `diffuseproject/sampleworks:latest`) instead of hardcoded `sampleworks:latest`

## Context

PR #141 merged the RF3/Protenix checkpoint support but the Dockerfile still used `curl` downloads for Boltz checkpoints and `COPY checkpoints/...` from build context for RF3/Protenix. This caused CI to fail because:
1. The `COPY checkpoints/rf3_...` and `COPY checkpoints/protenix_...` files don't exist on the CI runner
2. The `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets were also missing (now added)

The checkpoints base image (`diffuseproject/sampleworks-checkpoints:latest`) was already built and pushed to Docker Hub from the GPU server, containing all 6 checkpoint items (boltz1, boltz2, ccd, mols/, rf3, protenix).

## Testing

- Docker Hub secrets (`DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`) have been added to the repo
- The checkpoints base image is verified present on Docker Hub
- CI should now pass with this Dockerfile change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed environment variables for selecting checkpoint paths and for choosing the runtime image, and updated container startup behavior (new default entrypoint/command).

* **Chores**
  * Docker builds now source model checkpoints from a pre-built external image and ignore local checkpoint files.
  * Simplified build pipeline by removing inline checkpoint operations.
  * CI workflow triggers extended to run on related script changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->