### PR TITLE
fix(rf3): RF3 was setting up its model_atom_array with elements not in the structure we processed (e.g. Se -> S) which caused a scattering table OOB error

### DIFF
--- a/src/sampleworks/core/forward_models/xray/real_space_density_deps/qfit/sf.py
+++ b/src/sampleworks/core/forward_models/xray/real_space_density_deps/qfit/sf.py
@@ -1381,3 +1381,34 @@ ELECTRON_SCATTERING_FACTORS = {
         [0.1310, 1.4038, 7.6057, 34.0186, 90.5226],
     ],
 }
+
+
+def _build_element_to_scattering_index() -> dict[str, int]:
+    """Build mapping from all element symbols to unique scattering tensor indices.
+
+    Neutral elements retain their atomic-number indices from
+    ``ELEMENT_TO_ATOMIC_NUM``.  Ionic forms (e.g. ``'O1-'``, ``'Fe2+'``) are assigned unique
+    indices starting after the maximum atomic number.
+
+    Returns
+    -------
+    dict[str, int]
+        Mapping from element symbol to scattering tensor index.
+    """
+    mapping = dict(ELEMENT_TO_ATOMIC_NUM)
+    next_idx = max(ELEMENT_TO_ATOMIC_NUM.values()) + 1
+    all_sf_keys = sorted(
+        set(ATOM_STRUCTURE_FACTORS.keys()) | set(ELECTRON_SCATTERING_FACTORS.keys())
+    )
+    for key in all_sf_keys:
+        if key not in mapping:
+            mapping[key] = next_idx
+            next_idx += 1
+    return mapping
+
+
+ELEMENT_TO_SCATTERING_INDEX: dict[str, int] = _build_element_to_scattering_index()
+"""Extended element to index mapping covering ionic forms. Ionic forms
+(e.g. ``'O1-'``, ``'Fe2+'``) receive unique indices beyond the periodic
+table so their distinct scattering factors are preserved.
+"""

--- a/src/sampleworks/core/rewards/protocol.py
+++ b/src/sampleworks/core/rewards/protocol.py
@@ -6,10 +6,8 @@ from typing import Protocol, runtime_checkable, TYPE_CHECKING
 import einx
 import numpy as np
 import torch
-from jaxtyping import Float
-from sampleworks.core.forward_models.xray.real_space_density_deps.qfit.sf import (
-    ELEMENT_TO_ATOMIC_NUM,
-)
+from jaxtyping import Float, Int
+from sampleworks.utils.elements import elements_to_scattering_indices
 
 
 if TYPE_CHECKING:
@@ -30,7 +28,7 @@ class RewardInputs:
     noise and setting occupancy to 1.0 for model-operated atoms).
     """
 
-    elements: Float[torch.Tensor, "*batch n_atoms"]
+    elements: Int[torch.Tensor, "*batch n_atoms"]
     b_factors: Float[torch.Tensor, "*batch n_atoms"]
     occupancies: Float[torch.Tensor, "*batch n_atoms"]
     input_coords: Float[torch.Tensor, "*batch n_atoms 3"]
@@ -76,7 +74,7 @@ class RewardInputs:
         if np.any((atom_array.occupancy <= 0) | (atom_array.occupancy > 1)):
             raise ValueError("Atom array contains invalid occupancy values.")
 
-        elements_list = [ELEMENT_TO_ATOMIC_NUM[e.title()] for e in atom_array.element]
+        elements_list = elements_to_scattering_indices(atom_array.element)
 
         total_batch_size = num_particles * ensemble_size if num_particles > 1 else ensemble_size
 
@@ -88,7 +86,10 @@ class RewardInputs:
         # b_factors across the particle dimension.
         if num_particles > 1:
             elements = einx.rearrange(
-                "n -> p e n", torch.Tensor(elements_list), p=num_particles, e=ensemble_size
+                "n -> p e n",
+                torch.tensor(elements_list, dtype=torch.long),
+                p=num_particles,
+                e=ensemble_size,
             )
             b_factors = einx.rearrange(
                 "n -> p e n",
@@ -103,7 +104,9 @@ class RewardInputs:
                 b=total_batch_size,
             )
         else:
-            elements = einx.rearrange("n -> b n", torch.Tensor(elements_list), b=ensemble_size)
+            elements = einx.rearrange(
+                "n -> b n", torch.tensor(elements_list, dtype=torch.long), b=ensemble_size
+            )
             b_factors = einx.rearrange(
                 "n -> b n",
                 torch.Tensor(atom_array.b_factor),
@@ -138,7 +141,7 @@ class RewardFunctionProtocol(Protocol):
     def __call__(
         self,
         coordinates: Float[torch.Tensor, "batch n_atoms 3"],
-        elements: Float[torch.Tensor, "batch n_atoms"],
+        elements: Int[torch.Tensor, "batch n_atoms"],
         b_factors: Float[torch.Tensor, "batch n_atoms"],
         occupancies: Float[torch.Tensor, "batch n_atoms"],
         unique_combinations: torch.Tensor | None = None,
@@ -181,8 +184,8 @@ class PrecomputableRewardFunctionProtocol(RewardFunctionProtocol, Protocol):
 
     def precompute_unique_combinations(
         self,
-        elements: torch.Tensor,
-        b_factors: torch.Tensor,
+        elements: Int[torch.Tensor, "batch n_atoms"],
+        b_factors: Float[torch.Tensor, "batch n_atoms"],
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Pre-compute unique (element, b_factor) combinations.
 

--- a/src/sampleworks/core/rewards/real_space_density.py
+++ b/src/sampleworks/core/rewards/real_space_density.py
@@ -12,56 +12,56 @@ from sampleworks.core.forward_models.xray.real_space_density import (
 from sampleworks.core.forward_models.xray.real_space_density_deps.qfit.sf import (
     ATOM_STRUCTURE_FACTORS,
     ELECTRON_SCATTERING_FACTORS,
-    ELEMENT_TO_ATOMIC_NUM,
+    ELEMENT_TO_SCATTERING_INDEX,
 )
 from sampleworks.core.forward_models.xray.real_space_density_deps.qfit.volume import (
     XMap,
 )
-from sampleworks.utils.elements import normalize_element
+from sampleworks.utils.elements import elements_to_scattering_indices
+from sampleworks.utils.framework_utils import match_batch
 from sampleworks.utils.torch_utils import try_gpu
 
 
-def setup_scattering_params(
-    atom_array: AtomArray | AtomArrayStack, em_mode: bool, device: torch.device
-) -> torch.Tensor:
+def setup_scattering_params(em_mode: bool, device: torch.device) -> torch.Tensor:
     """Set up atomic scattering parameters for density calculation.
+
+    The returned tensor is indexed by the values in
+    :data:`ELEMENT_TO_SCATTERING_INDEX`
+
+    Any element without a tabulated scattering factor is left as zeros and logged
+    as it indicates an unrecognised element in the input
 
     Parameters
     ----------
-    atom_array
-        Structure containing atoms with element information
     em_mode
-        If True, use electron scattering factors (for cryo-EM).
-        If False, use X-ray scattering factors.
+        If ``True``, use electron scattering factors for cryo-EM. If
+        ``False``, use X-ray scattering factors.
     device
-        PyTorch device to place the scattering parameter tensor on
+        PyTorch device that should own the returned lookup tensor.
 
     Returns
     -------
     torch.Tensor
-        Scattering parameter tensor of shape (max_atomic_num + 1, n_coeffs, 2)
-        containing scattering coefficients for each element type
+        Tensor of shape ``(n_indices, n_coeffs, 2)`` containing scattering
+        coefficients.
     """
-    elements = atom_array.element
-    unique_elements = sorted(set(normalize_element(e) for e in elements))
-    atomic_num_dict = {elem: ELEMENT_TO_ATOMIC_NUM[elem] for elem in unique_elements}
-
     structure_factors = ELECTRON_SCATTERING_FACTORS if em_mode else ATOM_STRUCTURE_FACTORS
-
-    max_atomic_num = max(atomic_num_dict.values())
     n_coeffs = len(structure_factors["C"][0])
-    dense_size = torch.Size([max_atomic_num + 1, n_coeffs, 2])
-    scattering_tensor = torch.zeros(dense_size, dtype=torch.float32, device=device)
+    n_elements = max(ELEMENT_TO_SCATTERING_INDEX.values()) + 1
+    scattering_tensor = torch.zeros((n_elements, n_coeffs, 2), dtype=torch.float32, device=device)
 
-    for elem in unique_elements:
-        atomic_num = atomic_num_dict[elem]
-        if elem in structure_factors:
-            factor = structure_factors[elem]
-        else:
-            logger.warning(f"Scattering factors for {elem} not found, using C")
-            factor = structure_factors["C"]
-        factor_tensor = torch.tensor(factor, dtype=torch.float32, device=device).T
-        scattering_tensor[atomic_num, :, :] = factor_tensor
+    for element, idx in ELEMENT_TO_SCATTERING_INDEX.items():
+        if element not in structure_factors or element == "?":
+            logger.warning(
+                f"Element '{element}' (scattering index {idx}) has no tabulated "
+                "scattering factors and will contribute zero density. This indicates "
+                "the scattering factor table is incomplete for this element."
+            )
+            continue
+        factor_tensor = torch.tensor(
+            structure_factors[element], dtype=torch.float32, device=device
+        ).T
+        scattering_tensor[idx] = factor_tensor
 
     return scattering_tensor
 
@@ -152,11 +152,8 @@ def extract_density_inputs_from_atomarray(
             )
 
     coords_tensor = torch.from_numpy(valid_coords.copy()).to(device, dtype=torch.float32)
-    elements_tensor = torch.tensor(
-        [ELEMENT_TO_ATOMIC_NUM[normalize_element(e)] for e in valid_elements],
-        device=device,
-        dtype=torch.long,
-    )
+    element_indices = elements_to_scattering_indices(valid_elements)
+    elements_tensor = torch.tensor(element_indices, device=device, dtype=torch.long)
     b_factors_tensor = torch.from_numpy(valid_b_factor.copy()).to(device, dtype=torch.float32)
 
     nan_b_factor_mask = torch.isnan(b_factors_tensor)
@@ -260,14 +257,29 @@ class RealSpaceRewardFunction:
 
     def structure_to_reward_input(self, structure: dict) -> dict[str, Float[torch.Tensor, "..."]]:
         atom_array = structure["asym_unit"]
-        atom_array = atom_array[:, atom_array.occupancy > 0]
-        elements = [ELEMENT_TO_ATOMIC_NUM[normalize_element(elem)] for elem in atom_array.element]
+        mask = atom_array.occupancy > 0
+        if isinstance(atom_array, AtomArrayStack):
+            atom_array = atom_array[:, mask]
+        else:
+            atom_array = atom_array[mask]
 
-        elements = torch.tensor(elements, device=self.device).unsqueeze(0)
+        element_indices = elements_to_scattering_indices(atom_array.element)
+
+        elements = torch.tensor(element_indices, device=self.device, dtype=torch.long).unsqueeze(0)
         b_factors = torch.from_numpy(atom_array.b_factor).to(self.device).unsqueeze(0)
         occupancies = torch.from_numpy(atom_array.occupancy).to(self.device).unsqueeze(0)
 
         coordinates = torch.from_numpy(atom_array.coord).to(self.device)
+        if coordinates.ndim == 2:
+            coordinates = coordinates.unsqueeze(0)
+
+        # AtomArrayStack: coord is (n_models, n_atoms, 3) but annotations are
+        # (n_atoms), so elements/b_factors/occupancies are (1, n_atoms) after
+        # unsqueeze while coordinates is (n_models, n_atoms, 3). Broadcast to match.
+        n_models = coordinates.shape[0]
+        elements = match_batch(elements, target_batch_size=n_models)
+        b_factors = match_batch(b_factors, target_batch_size=n_models)
+        occupancies = match_batch(occupancies, target_batch_size=n_models)
 
         return {
             "coordinates": coordinates,
@@ -279,7 +291,7 @@ class RealSpaceRewardFunction:
     def __call__(
         self,
         coordinates: Float[torch.Tensor, "batch n_atoms 3"],
-        elements: Float[torch.Tensor, "batch n_atoms"],
+        elements: Int[torch.Tensor, "batch n_atoms"],
         b_factors: Float[torch.Tensor, "batch n_atoms"],
         occupancies: Float[torch.Tensor, "batch n_atoms"],
         unique_combinations: torch.Tensor | None = None,
@@ -292,7 +304,7 @@ class RealSpaceRewardFunction:
         ----------
         coordinates: Float[torch.Tensor, "batch n_atoms 3"]
             Atomic coordinates
-        elements: Float[torch.Tensor, "batch n_atoms"]
+        elements: Int[torch.Tensor, "batch n_atoms"]
             Atomic elements
         b_factors: Float[torch.Tensor, "batch n_atoms"]
             Per-atom B-factor

--- a/src/sampleworks/models/rf3/wrapper.py
+++ b/src/sampleworks/models/rf3/wrapper.py
@@ -222,7 +222,7 @@ class RF3Wrapper:
         Returns
         -------
         GenerativeModelInput[RF3Conditioning]
-            Model input with x_init and trunk conditioning.
+            Model input with ``x_init`` and trunk conditioning.
         """
         config = structure.get("_rf3_config", RF3Config())
         if isinstance(config, dict):
@@ -354,15 +354,19 @@ class RF3Wrapper:
             model_atom_array=model_aa,
         )
 
-        # x_init should be the reference coordinates for alignment purposes.
-        if true_atom_array is not None and len(true_atom_array) == num_atoms:
+        # x_init here is a shape-compatible reference carried with the featurized
+        # model input. During guided sampling, alignment/reference coordinates are
+        # built later via process_structure_to_trajectory_input() and AtomReconciler.
+        # TODO: figure out if this is necessary or if we should just remove x_init completely.
+        if len(true_atom_array) == num_atoms:
             x_init = torch.tensor(true_atom_array.coord, device=self.device, dtype=torch.float32)
-            x_init = match_batch(x_init.unsqueeze(0), target_batch_size=ensemble_size).clone()
+            x_init = match_batch(x_init.unsqueeze(0), target_batch_size=ensemble_size)
         else:
-            logger.warning(
-                "True structure not available or atom count mismatch; initializing "
-                "x_init from prior. This means align_to_input will not work properly,"
-                " and reward functions dependent on this won't be accurate."
+            logger.info(
+                f"Input structure has {len(true_atom_array)} atoms, but RF3 operates on "
+                f"{num_atoms} atoms after model-specific preprocessing. Initializing "
+                "x_init from prior to match model shape; guided sampling will "
+                "reconcile alignment and reward inputs later on the common atom subset."
             )
             x_init = self.initialize_from_prior(batch_size=ensemble_size, shape=(num_atoms, 3))
 

--- a/src/sampleworks/utils/density_utils.py
+++ b/src/sampleworks/utils/density_utils.py
@@ -137,7 +137,7 @@ def compute_density_from_atomarray(
     if xmap is None:
         xmap = create_synthetic_grid(atom_array, resolution, padding=5.0)  # ty: ignore[invalid-argument-type] (resolution will not be None here)
 
-    scattering_params = setup_scattering_params(atom_array, em_mode, device)
+    scattering_params = setup_scattering_params(em_mode=em_mode, device=device)
 
     xmap_torch = XMap_torch(xmap, device=device)
     transformer = DifferentiableTransformer(

--- a/src/sampleworks/utils/elements.py
+++ b/src/sampleworks/utils/elements.py
@@ -1,8 +1,11 @@
+from collections.abc import Iterable
+
 from loguru import logger
 
 from sampleworks.core.forward_models.xray.real_space_density_deps.qfit.sf import (
     ATOM_STRUCTURE_FACTORS,
     ATOMIC_NUM_TO_ELEMENT,
+    ELEMENT_TO_SCATTERING_INDEX,
 )
 
 
@@ -15,3 +18,51 @@ def normalize_element(elem: str) -> str:
     if normalized not in VALID_ELEMENTS:
         logger.warning(f"Unrecognized element symbol: '{elem}' (normalized: '{normalized}')")
     return normalized
+
+
+def element_to_scattering_idx(raw: str) -> int:
+    """Normalize an element symbol and return its scattering tensor index.
+
+    Unknown elements are logged and mapped to index 0 (the ``'?'``
+    placeholder row, which carries zero scattering factors).
+
+    Parameters
+    ----------
+    raw
+        Raw element symbol as found on an ``AtomArray`` (e.g. ``'CA'``,
+        ``'Fe2+'``, ``'SE'``).
+
+    Returns
+    -------
+    int
+        Index into the scattering parameter tensor built by
+        ``setup_scattering_params``.
+    """
+    normalized = normalize_element(raw)
+    idx = ELEMENT_TO_SCATTERING_INDEX.get(normalized)
+    if idx is None:
+        logger.warning(
+            f"Element '{raw}' (normalized: '{normalized}') is not in the scattering "
+            "index table and will contribute zero density."
+        )
+        return 0
+    return idx
+
+
+def elements_to_scattering_indices(elements: Iterable[str]) -> list[int]:
+    """Map a sequence of raw element symbols to scattering tensor indices.
+
+    Convenience wrapper around :func:`element_to_scattering_idx` for the
+    common case of converting an entire ``AtomArray.element`` array.
+
+    Parameters
+    ----------
+    elements
+        Iterable of raw element symbols.
+
+    Returns
+    -------
+    list[int]
+        Scattering tensor indices, one per input element.
+    """
+    return [element_to_scattering_idx(e) for e in elements]

--- a/src/sampleworks/utils/guidance_script_utils.py
+++ b/src/sampleworks/utils/guidance_script_utils.py
@@ -239,7 +239,7 @@ def get_reward_function_and_structure(
     logger.debug("Setting up scattering parameters")
 
     atom_array = structure["asym_unit"]
-    scattering_params = setup_scattering_params(atom_array=atom_array, em_mode=em, device=device)
+    scattering_params = setup_scattering_params(em_mode=em, device=device)
 
     selection_mask = atom_array.occupancy > 0
     n_selected = selection_mask.sum()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -650,9 +650,7 @@ def reward_function_1vme(density_map_1vme, structure_1vme_density, device: torch
         setup_scattering_params,
     )
 
-    params = setup_scattering_params(
-        structure_1vme_density["asym_unit"], em_mode=False, device=device
-    )
+    params = setup_scattering_params(em_mode=False, device=device)
     rf = RealSpaceRewardFunction(density_map_1vme, params, torch.tensor([1], device=device))
     return rf
 

--- a/tests/integration/test_mismatch_integration.py
+++ b/tests/integration/test_mismatch_integration.py
@@ -677,7 +677,7 @@ class TestPreprocessingPipeline:
         n_model = mismatch_case.n_model
         assert reward_inputs.elements.shape[-1] == n_model
         assert reward_inputs.b_factors.shape[-1] == n_model
-        assert reward_inputs.input_coords.shape[-2] == n_model
+        assert reward_inputs.occupancies.shape[-1] == n_model
         assert reward_inputs.input_coords.shape[-2] == n_model
 
     def test_b_factor_override(self, mismatch_case: MismatchCase):

--- a/tests/rewards/test_real_space_density_reward.py
+++ b/tests/rewards/test_real_space_density_reward.py
@@ -14,14 +14,99 @@ from functools import partial
 from typing import cast
 
 import einx
+import numpy as np
 import pytest
 import torch
 from sampleworks.core.forward_models.xray.real_space_density_deps.qfit.sf import (
+    ATOM_STRUCTURE_FACTORS,
     ELEMENT_TO_ATOMIC_NUM,
 )
 from sampleworks.core.rewards.real_space_density import (
+    extract_density_inputs_from_atomarray,
     RealSpaceRewardFunction,
+    setup_scattering_params,
 )
+
+
+class TestSetupScatteringParams:
+    """Test structure-independent scattering parameter lookup construction."""
+
+    def test_setup_scattering_params_covers_supported_elements(self, device):
+        """Every key in ATOM_STRUCTURE_FACTORS must have a nonzero row in the
+        scattering tensor, and its exact coefficients must match the table."""
+        from sampleworks.core.rewards.real_space_density import ELEMENT_TO_SCATTERING_INDEX
+
+        params = setup_scattering_params(em_mode=False, device=device)
+
+        assert params.shape[0] == max(ELEMENT_TO_SCATTERING_INDEX.values()) + 1
+
+        for element, coeffs in ATOM_STRUCTURE_FACTORS.items():
+            idx = ELEMENT_TO_SCATTERING_INDEX[element]
+            expected = torch.tensor(coeffs, dtype=torch.float32, device=device).T
+            torch.testing.assert_close(
+                params[idx],
+                expected,
+                msg=lambda m: f"Mismatch for '{element}': {m}",
+            )
+
+    def test_unknown_placeholder_row_is_zeros(self, device):
+        """The '?' placeholder occupies atomic number 0 and has no scattering factors,
+        so its row in the lookup table must be all zeros."""
+        params = setup_scattering_params(em_mode=False, device=device)
+        assert torch.all(params[ELEMENT_TO_ATOMIC_NUM["?"]] == 0)
+
+    def test_pdb_allcaps_elements_resolve_to_correct_atomic_numbers(
+        self, atom_array_with_nan_coords, device
+    ):
+        """PDB files store elements in all-caps (e.g. 'NA', 'CA', 'SE').
+        normalize_element must convert these to standard title-case symbols so they
+        map to the correct atomic number and carry nonzero scattering factors.
+        """
+        params = setup_scattering_params(em_mode=False, device=device)
+        aa = atom_array_with_nan_coords.copy()
+        aa.element = np.array(["NA", "C", "CA", "C", "SE"])
+        _, elements, _, _ = extract_density_inputs_from_atomarray(aa, device)
+        expected = torch.tensor(
+            [ELEMENT_TO_ATOMIC_NUM[e] for e in ["Na", "Ca", "Se"]],
+            dtype=torch.long,
+            device=device,
+        )
+        assert torch.equal(elements.squeeze(0), expected)
+        assert all(params[idx].sum().item() != 0 for idx in expected)
+
+    def test_ionic_element_gets_proper_density(self, atom_array_with_nan_coords, device):
+        """Ionic element symbols such as 'O1-' are present in ATOM_STRUCTURE_FACTORS
+        but absent from ELEMENT_TO_ATOMIC_NUM (which only holds neutral-atom symbols).
+        We need to detect this and return the proper scattering params."""
+        params = setup_scattering_params(em_mode=False, device=device)
+        aa = atom_array_with_nan_coords.copy()
+        aa.element = np.array(["O1-", "C", "FE2+", "C", "CL1-"])
+        _, elements, _, _ = extract_density_inputs_from_atomarray(aa, device)
+        surviving_elements = elements.squeeze(0)
+
+        assert all(idx.item() != 0 for idx in surviving_elements)
+
+        # Verify exact scattering factors from the ATOM_STRUCTURE_FACTORS table
+        for idx, ionic_key in zip(surviving_elements, ["O1-", "Fe2+", "Cl1-"]):
+            expected = torch.tensor(
+                ATOM_STRUCTURE_FACTORS[ionic_key],
+                dtype=torch.float32,
+                device=device,
+            ).T
+            torch.testing.assert_close(params[idx], expected)
+
+    def test_completely_unknown_element_falls_back_to_zero_density(
+        self, atom_array_with_nan_coords, device
+    ):
+        """An element symbol that is not recognised at all (neither in
+        ELEMENT_TO_ATOMIC_NUM nor in the structure factor table) falls back to
+        atomic number 0 and contributes zero density."""
+        params = setup_scattering_params(em_mode=False, device=device)
+        aa = atom_array_with_nan_coords.copy()
+        aa.element = np.array(["Xx", "C", "C", "C", "C"])
+        _, elements, _, _ = extract_density_inputs_from_atomarray(aa, device)
+        assert elements.squeeze(0)[0].item() == 0
+        assert params[0].sum().item() == 0
 
 
 @pytest.mark.gpu


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added integer-based element-to-scattering index mapping and user helpers to map element symbols (including ionic/nonstandard forms) to indices; public setup/extract helpers updated to use these indices.

* **Bug Fixes**
  * Improved error logging and deterministic fallback to zero-density when elements are unrecognized.

* **Refactor**
  * Public APIs now represent elements as integer scattering indices; input shapes and signatures adjusted accordingly.

* **Tests**
  * Added tests covering element mapping, ionic handling, and fallback-to-zero behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->