### PR TITLE
fix(log): pass and log altloc_occ dict rather than float to get base map

### DIFF
--- a/scripts/eval/rscc_grid_search_script.py
+++ b/scripts/eval/rscc_grid_search_script.py
@@ -64,9 +64,10 @@ def main(args: argparse.Namespace):
     logger.debug("Testing base map path resolution:")
     for _, config in protein_configs.items():
         for occ in args.occupancies:
-            path = config.get_base_map_path_for_occupancy(occ)  # will warn if not found
+            altloc_occ = {"A": occ, "B": 1.0 - occ}
+            path = config.get_base_map_path_for_occupancy(altloc_occ)  # will warn if not found
             if path:
-                logger.debug(f"  {config.protein} occ={occ}: {path}")
+                logger.debug(f"  {config.protein} occupancies={altloc_occ}: {path}")
 
     # Scan for trials (look for refined.cif files)
     all_trials = scan_grid_search_results(grid_search_dir, target_filename=args.target_filename)

--- a/tests/eval/test_eval_dataclasses.py
+++ b/tests/eval/test_eval_dataclasses.py
@@ -4,7 +4,7 @@ import math
 from pathlib import Path
 
 import pytest
-from sampleworks.eval.eval_dataclasses import Trial, TrialList
+from sampleworks.eval.eval_dataclasses import ProteinConfig, Trial, TrialList
 
 
 @pytest.fixture
@@ -131,3 +131,44 @@ class TestTrialList:
         tl = TrialList()
         with caplog.at_level(logging.INFO):
             tl.summarize()  # should not raise
+
+
+@pytest.fixture
+def protein_config(tmp_path: Path) -> ProteinConfig:
+    return ProteinConfig(
+        protein="test",
+        base_map_dir=tmp_path,
+        selection=["chain A"],
+        resolution=2.0,
+        map_pattern="{occ_str}.ccp4",
+    )
+
+
+class TestProteinConfigGetBaseMapPath:
+    """Tests for ProteinConfig.get_base_map_path_for_occupancy (accepts dict, not float)."""
+
+    def test_returns_path_when_file_exists(self, protein_config, tmp_path):
+        map_file = tmp_path / "0.5occA_0.5occB.ccp4"
+        map_file.touch()
+        assert protein_config.get_base_map_path_for_occupancy({"A": 0.5, "B": 0.5}) == map_file
+
+    def test_returns_none_when_file_missing(self, protein_config):
+        assert protein_config.get_base_map_path_for_occupancy({"A": 0.5, "B": 0.5}) is None
+
+    def test_zero_occ_altloc_dropped_from_filename(self, protein_config, tmp_path):
+        """{"A": 1.0, "B": 0.0} should resolve to "1.0occA.ccp4", drop the zero-occ altloc."""
+        map_file = tmp_path / "1.0occA.ccp4"
+        map_file.touch()
+        assert protein_config.get_base_map_path_for_occupancy({"A": 1.0, "B": 0.0}) == map_file
+
+    def test_all_zero_occupancies_returns_none_with_warning(self, protein_config, caplog):
+        """All-zero dict → occupancy_to_str raises → None + warning."""
+        result = protein_config.get_base_map_path_for_occupancy({"A": 0.0, "B": 0.0})
+        assert result is None
+        assert "Cannot determine occupancy string" in caplog.text
+
+    def test_sum_exceeds_one_returns_none_with_warning(self, protein_config, caplog):
+        """Sum > 1 → occupancy_to_str raises → None + warning."""
+        result = protein_config.get_base_map_path_for_occupancy({"A": 0.8, "B": 0.8})
+        assert result is None
+        assert "Cannot determine occupancy string" in caplog.text


### PR DESCRIPTION
Address issue #160 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Occupancy handling in grid-search evaluation updated to use explicit A/B occupancy mapping; logging updated to reflect the new mapping.

* **Tests**
  * Added tests covering base-map path resolution for varied occupancy scenarios: existing/missing maps, zero-occupancy pruning, all-zero and over-sum occupancies triggering warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->