### PR TITLE
fix(ci): switch gpu-tests to pull_request_target to prevent approval bypass

### DIFF
--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: gpu-tests-${{ github.event.pull_request.number || github.ref }}
+  group: gpu-tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install pixi
         uses: prefix-dev/setup-pixi@19eac09b398e3d0c747adc7921926a6d802df4da # v0.8.8

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          # pull_request_target checks out the base branch by default. We need
+          # the PR head to actually test PR code. This runs untrusted code on
+          # gpu-1, mitigated by: environment approval gate (gpu-testing),
+          # read-only token (contents: read), and reviewer sign-off before any
+          # steps execute. Reviewers: validate security-sensitive changes before
+          # approving.
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install pixi

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -47,7 +47,7 @@ jobs:
           # read-only token (contents: read), and reviewer sign-off before any
           # steps execute. Reviewers: validate security-sensitive changes before
           # approving.
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install pixi
         uses: prefix-dev/setup-pixi@19eac09b398e3d0c747adc7921926a6d802df4da # v0.8.8

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -9,7 +9,7 @@ on:
       - 'pyproject.toml'
       - 'pixi.lock'
       - '.github/workflows/gpu-tests.yml'
-  pull_request:
+  pull_request_target:
     branches: [main]
     paths:
       - 'src/**'
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: gpu-tests-${{ github.ref }}
+  group: gpu-tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install pixi
         uses: prefix-dev/setup-pixi@19eac09b398e3d0c747adc7921926a6d802df4da # v0.8.8

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: gpu-tests-${{ github.ref }}
+  group: gpu-tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- Switch `pull_request` to `pull_request_target` so the workflow definition always comes from `main`, preventing PRs from removing the `environment: gpu-testing` approval gate
- Fix concurrency group to use PR number (`github.ref` is always `refs/heads/main` for `pull_request_target` events, so all PRs would share one group)
- Add explicit `ref` to checkout step so PR code is tested instead of the base branch

## Test plan
- [x] Open a test PR that modifies `gpu-tests.yml` — verify the environment approval gate still fires
- [ ] Verify GPU tests still run and pass on a normal PR touching `src/` or `tests/`
- [ ] Confirm push-to-main and workflow_dispatch triggers still work (fallback to `github.sha`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated PR CI workflow to run tests using the PR's head commit, adjusted PR trigger behavior, and scoped concurrent runs by PR to improve reliability and consistency of automated GPU tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->