### PR TITLE
Add configurable recycling steps and diffusion step count parameters

### DIFF
--- a/run_grid_search.py
+++ b/run_grid_search.py
@@ -450,7 +450,15 @@ def parse_args() -> argparse.Namespace:
         "--recycling-steps",
         type=int,
         default=None,
-        help="Number of recycling steps for model inference (if not specified, uses model default)",
+        help="Number of recycling steps for model inference. If not specified, "
+        "uses model default, which can be found in each model's wrapper.py file",
+    )
+    parser.add_argument(
+        "--num-diffusion-steps",
+        type=int,
+        default=200,
+        help="Number of diffusion steps for model inference. If not specified, "
+        "uses model default, which can be found in each model's wrapper.py file",
     )
 
     # Trajectory scaling arguments
@@ -459,9 +467,6 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--ensemble-sizes", default="1 2 4 8", help="Space-separated ensemble sizes"
-    )
-    parser.add_argument(
-        "--num-diffusion-steps", type=int, default=200, help="Number of diffusion steps"
     )
     parser.add_argument(
         "--gradient-weights",

--- a/run_grid_search.py
+++ b/run_grid_search.py
@@ -114,6 +114,7 @@ def build_args_for_process_pool(
         augmentation=args.augmentation,
         align_to_input=args.align_to_input,
         recycling_steps=args.recycling_steps,
+        num_diffusion_steps=args.num_diffusion_steps,
     )
     # given model_type and guidance_type, the GuidanceConfig class will set itself up
     # with defaults for remaining required args, but we want to set them further here.
@@ -445,6 +446,12 @@ def parse_args() -> argparse.Namespace:
         choices=["X-RAY DIFFRACTION", "MD"],
         help="Method for Boltz2 ('X-RAY DIFFRACTION', 'MD')",
     )
+    parser.add_argument(
+        "--recycling-steps",
+        type=int,
+        default=None,
+        help="Number of recycling steps for model inference (if not specified, uses model default)",
+    )
 
     # Trajectory scaling arguments
     parser.add_argument(
@@ -452,6 +459,9 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--ensemble-sizes", default="1 2 4 8", help="Space-separated ensemble sizes"
+    )
+    parser.add_argument(
+        "--num-diffusion-steps", type=int, default=200, help="Number of diffusion steps"
     )
     parser.add_argument(
         "--gradient-weights",
@@ -490,14 +500,6 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--augmentation", action="store_true", help="Enable augmentation")
     parser.add_argument("--align-to-input", action="store_true", help="Align to input structure")
-
-    # Model-specific arguments
-    parser.add_argument(
-        "--recycling-steps",
-        type=int,
-        default=None,
-        help="Number of recycling steps for model inference (if not specified, uses model default)",
-    )
 
     # RF3-specific arguments
     parser.add_argument(

--- a/run_grid_search.py
+++ b/run_grid_search.py
@@ -113,6 +113,7 @@ def build_args_for_process_pool(
         gradient_normalization=args.gradient_normalization,
         augmentation=args.augmentation,
         align_to_input=args.align_to_input,
+        recycling_steps=args.recycling_steps,
     )
     # given model_type and guidance_type, the GuidanceConfig class will set itself up
     # with defaults for remaining required args, but we want to set them further here.
@@ -489,6 +490,14 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--augmentation", action="store_true", help="Enable augmentation")
     parser.add_argument("--align-to-input", action="store_true", help="Align to input structure")
+
+    # Model-specific arguments
+    parser.add_argument(
+        "--recycling-steps",
+        type=int,
+        default=None,
+        help="Number of recycling steps for model inference (if not specified, uses model default)",
+    )
 
     # RF3-specific arguments
     parser.add_argument(

--- a/src/sampleworks/models/boltz/wrapper.py
+++ b/src/sampleworks/models/boltz/wrapper.py
@@ -331,7 +331,7 @@ def process_structure_for_boltz(
     out_dir: str | Path | None = None,
     num_workers: int = 8,
     ensemble_size: int = 1,
-    recycling_steps: int = 3,
+    recycling_steps: int | None = 3,
 ) -> dict:
     """Annotate an Atomworks structure with Boltz-specific configuration.
 
@@ -346,14 +346,20 @@ def process_structure_for_boltz(
         Number of parallel workers for preprocessing.
     ensemble_size : int
         Number of samples to generate (batch dimension of x_init).
-    recycling_steps : int
+    recycling_steps : int | None
         Number of recycling steps to perform during featurization Pairformer pass.
+        Will set to 3 if None.
 
     Returns
     -------
     dict
         Structure dict with "_boltz_config" key added.
     """
+    # Other models define a default deeper in their code,
+    # but Boltz requires an integer value, so fix it here.
+    if recycling_steps is None:
+        recycling_steps = 3
+
     config = BoltzConfig(
         out_dir=out_dir or structure.get("metadata", {}).get("id", "boltz_output"),
         num_workers=num_workers,
@@ -441,7 +447,7 @@ def create_boltz_input_from_structure(
             sequence_to_chains.setdefault(seq, []).append(chain_id)
 
         unique_chain_sequences = {chains[0]: seq for seq, chains in sequence_to_chains.items()}
-        msa_paths_unique = msa_manager.get_msa(unique_chain_sequences, msa_pairing_strategy)
+        msa_paths_unique = msa_manager.get_msa(unique_chain_sequences, msa_pairing_strategy)  # ty: ignore[invalid-argument-type]
 
         msa_paths = {}
         for seq, chains_with_seq in sequence_to_chains.items():
@@ -603,7 +609,7 @@ class Boltz2Wrapper:
 
         processed_dir = out_dir / "processed"
         processed = BoltzProcessedInput(
-            manifest=Manifest.load(processed_dir / "manifest.json"),  # type: ignore (Boltz repo doesn't have the right type hints?)
+            manifest=Manifest.load(processed_dir / "manifest.json"),
             targets_dir=processed_dir / "structures",
             msa_dir=processed_dir / "msa",
             constraints_dir=(processed_dir / "constraints")
@@ -783,27 +789,25 @@ class Boltz2Wrapper:
 
             if self.model.use_templates:
                 if self.model.is_template_compiled:
-                    template_module = (
-                        self.model.template_module._orig_mod  # type: ignore (compiled torch module has this attribute, type checker doesn't know)
-                    )
+                    template_module = self.model.template_module._orig_mod
                 else:
                     template_module = self.model.template_module
 
-                z = z + template_module(z, features, pair_mask, use_kernels=self.model.use_kernels)  # type: ignore (Object will be callable here)
+                z = z + template_module(z, features, pair_mask, use_kernels=self.model.use_kernels)
 
             if self.model.is_msa_compiled:
-                msa_module = self.model.msa_module._orig_mod  # type: ignore (compiled torch module has this attribute, type checker doesn't know)
+                msa_module = self.model.msa_module._orig_mod
             else:
                 msa_module = self.model.msa_module
 
-            z = z + msa_module(z, s_inputs, features, use_kernels=self.model.use_kernels)  # type: ignore (Object will be callable here)
+            z = z + msa_module(z, s_inputs, features, use_kernels=self.model.use_kernels)
 
             if self.model.is_pairformer_compiled:
-                pairformer_module = self.model.pairformer_module._orig_mod  # type: ignore (compiled torch module has this attribute, type checker doesn't know)
+                pairformer_module = self.model.pairformer_module._orig_mod
             else:
                 pairformer_module = self.model.pairformer_module
 
-            s, z = pairformer_module(s, z, mask=mask, pair_mask=pair_mask)  # type: ignore (Object will be callable here)
+            s, z = pairformer_module(s, z, mask=mask, pair_mask=pair_mask)
 
         q, c, to_keys, atom_enc_bias, atom_dec_bias, token_trans_bias = (
             self.model.diffusion_conditioning(
@@ -1068,7 +1072,7 @@ class Boltz1Wrapper:
 
         processed_dir = out_dir / "processed"
         processed = BoltzProcessedInput(
-            manifest=Manifest.load(processed_dir / "manifest.json"),  # type: ignore (Boltz repo doesn't have the right type hints?)
+            manifest=Manifest.load(processed_dir / "manifest.json"),
             targets_dir=processed_dir / "structures",
             msa_dir=processed_dir / "msa",
             constraints_dir=(processed_dir / "constraints")
@@ -1357,7 +1361,7 @@ class Boltz1Wrapper:
                 )
 
             if self.model.is_pairformer_compiled:
-                pairformer_module = self.model.pairformer_module._orig_mod  # type: ignore (compiled torch module has this attribute, type checker doesn't know)
+                pairformer_module = self.model.pairformer_module._orig_mod
             else:
                 pairformer_module = self.model.pairformer_module
 
@@ -1367,7 +1371,7 @@ class Boltz1Wrapper:
                 mask=mask,
                 pair_mask=pair_mask,
                 use_kernels=self.model.use_kernels,
-            )  # type: ignore (Object will be callable here)
+            )
 
         return {
             "s": s,

--- a/src/sampleworks/models/protenix/wrapper.py
+++ b/src/sampleworks/models/protenix/wrapper.py
@@ -687,9 +687,9 @@ class ProtenixWrapper:
             s_inputs=s_inputs,
             s_trunk=s_trunk,
             z_trunk=z_trunk,
-            pair_z=pair_z,  # ty: ignore[invalid-argument-type]
-            p_lm=p_lm,  # ty: ignore[invalid-argument-type]
-            c_l=c_l,  # ty: ignore[invalid-argument-type]
+            pair_z=pair_z,
+            p_lm=p_lm,
+            c_l=c_l,
         )
 
         # TODO: is there a way to handle this more cleanly?

--- a/src/sampleworks/models/rf3/wrapper.py
+++ b/src/sampleworks/models/rf3/wrapper.py
@@ -205,8 +205,6 @@ class RF3Wrapper:
         self.msa_manager = msa_manager
         self.msa_pairing_strategy = "greedy"
 
-        # TODO: expose num_steps, num_recycles to user
-
         self.inference_engine = RF3InferenceEngine(
             ckpt_path=str(self.checkpoint_path),
             diffusion_batch_size=1,

--- a/src/sampleworks/utils/guidance_script_arguments.py
+++ b/src/sampleworks/utils/guidance_script_arguments.py
@@ -137,6 +137,7 @@ class GuidanceConfig:
     guidance_start: int = -1
     augmentation: bool = False
     align_to_input: bool = False
+    recycling_steps: int | None = None
 
     # DO NOT remove the **kwargs, it is for compatibility with argparse.
     def add_argument(self, name: str, default: Any = None, **kwargs):

--- a/src/sampleworks/utils/guidance_script_arguments.py
+++ b/src/sampleworks/utils/guidance_script_arguments.py
@@ -138,6 +138,7 @@ class GuidanceConfig:
     augmentation: bool = False
     align_to_input: bool = False
     recycling_steps: int | None = None
+    num_diffusion_steps: int = 200
 
     # DO NOT remove the **kwargs, it is for compatibility with argparse.
     def add_argument(self, name: str, default: Any = None, **kwargs):

--- a/src/sampleworks/utils/guidance_script_utils.py
+++ b/src/sampleworks/utils/guidance_script_utils.py
@@ -27,7 +27,6 @@ from sampleworks.core.scalers.fk_steering import FKSteering
 from sampleworks.core.scalers.pure_guidance import PureGuidance
 from sampleworks.core.scalers.step_scalers import (
     DataSpaceDPSScaler,
-    NoScalingScaler,
     NoiseSpaceDPSScaler,
     NoScalingScaler,
 )
@@ -232,7 +231,7 @@ def get_reward_function_and_structure(
     logger.debug(f"Loading structure from {structure_path}")
     safe_structure_path = resolve_mixed_hetatm_atom_altlocs(Path(structure_path))
     structure = parse(
-        Path(safe_structure_path),
+        safe_structure_path,
         hydrogen_policy="remove",
         add_missing_atoms=False,
         ccd_mirror_path=None,
@@ -428,14 +427,22 @@ def _run_guidance(
     is_boltz = "Boltz" in wrapper_class_name
 
     # Annotate structure with model-specific configuration (including recycling_steps)
+    # See https://github.com/diff-use/sampleworks/issues/192 for a plan to organize this better.
     recycling_steps = getattr(args, "recycling_steps", None)
+    if recycling_steps is not None and recycling_steps <= 0:
+        raise ValueError("recycling_steps must be > 0")
+    if args.num_diffusion_steps is not None and args.num_diffusion_steps <= 0:
+        raise ValueError("num_diffusion_steps must be > 0")
+
     if "Protenix" in wrapper_class_name:
         from sampleworks.models.protenix.wrapper import annotate_structure_for_protenix
+
         structure = annotate_structure_for_protenix(
             structure, ensemble_size=args.ensemble_size, recycling_steps=recycling_steps
         )
     elif "RF3" in wrapper_class_name:
         from sampleworks.models.rf3.wrapper import annotate_structure_for_rf3
+
         structure = annotate_structure_for_rf3(
             structure,
             ensemble_size=args.ensemble_size,
@@ -446,6 +453,7 @@ def _run_guidance(
         )
     elif "Boltz" in wrapper_class_name:
         from sampleworks.models.boltz.wrapper import process_structure_for_boltz
+
         structure = process_structure_for_boltz(
             structure, ensemble_size=args.ensemble_size, recycling_steps=recycling_steps
         )

--- a/src/sampleworks/utils/guidance_script_utils.py
+++ b/src/sampleworks/utils/guidance_script_utils.py
@@ -27,6 +27,7 @@ from sampleworks.core.scalers.fk_steering import FKSteering
 from sampleworks.core.scalers.pure_guidance import PureGuidance
 from sampleworks.core.scalers.step_scalers import (
     DataSpaceDPSScaler,
+    NoScalingScaler,
     NoiseSpaceDPSScaler,
     NoScalingScaler,
 )
@@ -231,7 +232,7 @@ def get_reward_function_and_structure(
     logger.debug(f"Loading structure from {structure_path}")
     safe_structure_path = resolve_mixed_hetatm_atom_altlocs(Path(structure_path))
     structure = parse(
-        safe_structure_path,
+        Path(safe_structure_path),
         hydrogen_policy="remove",
         add_missing_atoms=False,
         ccd_mirror_path=None,
@@ -426,17 +427,30 @@ def _run_guidance(
     wrapper_class_name = model_wrapper.__class__.__name__
     is_boltz = "Boltz" in wrapper_class_name
 
-    # Annotate structure with RF3 specific config if applicable
-    if wrapper_class_name == "RF3Wrapper":
+    # Annotate structure with model-specific configuration (including recycling_steps)
+    recycling_steps = getattr(args, "recycling_steps", None)
+    if "Protenix" in wrapper_class_name:
+        from sampleworks.models.protenix.wrapper import annotate_structure_for_protenix
+        structure = annotate_structure_for_protenix(
+            structure, ensemble_size=args.ensemble_size, recycling_steps=recycling_steps
+        )
+    elif "RF3" in wrapper_class_name:
         from sampleworks.models.rf3.wrapper import annotate_structure_for_rf3
-
         structure = annotate_structure_for_rf3(
             structure,
-            msa_path=getattr(args, "msa_path", None),
             ensemble_size=args.ensemble_size,
+            recycling_steps=recycling_steps,
+            msa_path=getattr(args, "msa_path", None),
             disable_chiral_features=getattr(args, "disable_chiral_features", False),
             track_chiral_features=getattr(args, "track_chiral_features", False),
         )
+    elif "Boltz" in wrapper_class_name:
+        from sampleworks.models.boltz.wrapper import process_structure_for_boltz
+        structure = process_structure_for_boltz(
+            structure, ensemble_size=args.ensemble_size, recycling_steps=recycling_steps
+        )
+    else:
+        raise ValueError(f"Unknown model wrapper class: {wrapper_class_name}")
 
     # Boltz was trained with this, others might not have been.
     use_alignment_for_reverse_diffusion = is_boltz

--- a/src/sampleworks/utils/guidance_script_utils.py
+++ b/src/sampleworks/utils/guidance_script_utils.py
@@ -488,8 +488,7 @@ def _run_guidance(
     else:
         raise ValueError(f"Invalid step_scaler_type: {step_scaler_type}")
 
-    # TODO: this should be a config option
-    num_steps = 200
+    num_steps = args.num_diffusion_steps
 
     if guidance_type == GuidanceType.PURE_GUIDANCE:
         logger.info("Initializing pure guidance")


### PR DESCRIPTION
This PR adds two options to control diffusion: the total number of steps, and the number of recycling steps. These were used previously but with hard-coded values which are now surfaced to the user. They are passed to the respective models by use of the annotate* methods which append keyword config values to the structure dictionary. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI options to set recycling steps and override diffusion-step count (default 200).

* **Bug Fixes**
  * Validation for recycling and diffusion-step values; invalid values now raise clear errors.
  * Backend dispatch generalized so RF3, Boltz, and Protenix backends receive and honor recycling/diffusion settings; unknown backends produce explicit errors.

* **Chores**
  * Cleaned up inline type-check comments and normalized None recycling to a sensible default for Boltz.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->