### PR TITLE
fix(docker): combine pixi installs into single RUN to prevent disk-full

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,8 +10,6 @@ on:
     branches: [main]
     tags:
       - 'v*.*.*'
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 env:
@@ -40,8 +38,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-        with:
-          driver: docker
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4
@@ -68,7 +64,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: false
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,8 @@ on:
     branches: [main]
     tags:
       - 'v*.*.*'
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 env:
@@ -38,6 +40,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver: docker
 
       - name: Login to Docker Hub
         uses: docker/login-action@v4
@@ -64,7 +68,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: true
+          push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,10 +113,12 @@ RUN df -h /
 # ============================================================================
 # Install all three environments: boltz, protenix, rf3
 # ============================================================================
-# Split into separate layers so changing one env doesn't invalidate the others
-RUN df -h / && pixi install -e boltz --frozen && df -h /
-RUN df -h / && pixi install -e protenix --frozen && df -h /
-RUN df -h / && pixi install -e rf3 --frozen && df -h /
+# Single RUN to avoid layer accumulation — separate RUNs duplicate shared
+# packages across overlay layers, increasing peak disk usage.
+RUN df -h / && \
+    pixi install -e boltz --frozen && df -h / && \
+    pixi install -e protenix --frozen && df -h / && \
+    pixi install -e rf3 --frozen && df -h /
 
 # ============================================================================
 # Pre-compile CUDA extensions to avoid JIT compilation at runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,19 +104,25 @@ COPY docker-entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 # ============================================================================
-# Bake in model checkpoints from pre-built base image on Docker Hub
-# ============================================================================
-# Checkpoints (~10 GB) rarely change, so this layer is placed before pixi
-# installs to stay cached even when dependencies update.
-COPY --from=diffuseproject/sampleworks-checkpoints:latest /checkpoints/ /checkpoints/
-
-# ============================================================================
 # Install all three environments: boltz, protenix, rf3
 # ============================================================================
-# Split into separate layers so changing one env doesn't invalidate the others
-RUN pixi install -e boltz --frozen
-RUN pixi install -e protenix --frozen
-RUN pixi install -e rf3 --frozen
+# Split into separate layers so changing one env doesn't invalidate the others.
+# Pixi installs MUST run before checkpoint COPY — the checkpoint image (~10 GB)
+# consumes too much disk on CI runners when materialized before pixi,
+# causing "No space left on device" during conda package extraction.
+RUN df -h / && pixi install -e boltz --frozen && df -h /
+RUN df -h / && pixi install -e protenix --frozen && df -h /
+RUN df -h / && pixi install -e rf3 --frozen && df -h /
+
+# ============================================================================
+# Bake in model checkpoints from pre-built base image on Docker Hub
+# ============================================================================
+# Placed after pixi installs to reduce peak disk usage during CI builds.
+# The checkpoint layer is pulled in parallel by BuildKit regardless of order,
+# but COPY materializes it into the build graph — doing this last avoids
+# competing for disk with conda package extraction.
+RUN df -h /
+COPY --from=diffuseproject/sampleworks-checkpoints:latest /checkpoints/ /checkpoints/
 
 # ============================================================================
 # Pre-compile CUDA extensions to avoid JIT compilation at runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,25 +104,19 @@ COPY docker-entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 # ============================================================================
+# Bake in model checkpoints from pre-built base image on Docker Hub
+# ============================================================================
+RUN df -h /
+COPY --from=diffuseproject/sampleworks-checkpoints:latest /checkpoints/ /checkpoints/
+RUN df -h /
+
+# ============================================================================
 # Install all three environments: boltz, protenix, rf3
 # ============================================================================
-# Split into separate layers so changing one env doesn't invalidate the others.
-# Pixi installs MUST run before checkpoint COPY — the checkpoint image (~10 GB)
-# consumes too much disk on CI runners when materialized before pixi,
-# causing "No space left on device" during conda package extraction.
+# Split into separate layers so changing one env doesn't invalidate the others
 RUN df -h / && pixi install -e boltz --frozen && df -h /
 RUN df -h / && pixi install -e protenix --frozen && df -h /
 RUN df -h / && pixi install -e rf3 --frozen && df -h /
-
-# ============================================================================
-# Bake in model checkpoints from pre-built base image on Docker Hub
-# ============================================================================
-# Placed after pixi installs to reduce peak disk usage during CI builds.
-# The checkpoint layer is pulled in parallel by BuildKit regardless of order,
-# but COPY materializes it into the build graph — doing this last avoids
-# competing for disk with conda package extraction.
-RUN df -h /
-COPY --from=diffuseproject/sampleworks-checkpoints:latest /checkpoints/ /checkpoints/
 
 # ============================================================================
 # Pre-compile CUDA extensions to avoid JIT compilation at runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,19 +106,20 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 # ============================================================================
 # Bake in model checkpoints from pre-built base image on Docker Hub
 # ============================================================================
-RUN df -h /
+# Checkpoints (~10 GB) rarely change, so this layer is placed before pixi
+# installs to stay cached even when dependencies update.
 COPY --from=diffuseproject/sampleworks-checkpoints:latest /checkpoints/ /checkpoints/
-RUN df -h /
 
 # ============================================================================
 # Install all three environments: boltz, protenix, rf3
 # ============================================================================
-# Single RUN to avoid layer accumulation — separate RUNs duplicate shared
-# packages across overlay layers, increasing peak disk usage.
-RUN df -h / && \
-    pixi install -e boltz --frozen && df -h / && \
-    pixi install -e protenix --frozen && df -h / && \
-    pixi install -e rf3 --frozen && df -h /
+# IMPORTANT: Must be a single RUN — separate RUNs create overlay layers that
+# duplicate shared conda packages (numpy, CUDA libs, etc.), using ~37 GB vs
+# ~14 GB in a single layer. This difference causes disk-full failures on
+# smaller CI runners (ubuntu-latest can be 72 GB or 145 GB).
+RUN pixi install -e boltz --frozen && \
+    pixi install -e protenix --frozen && \
+    pixi install -e rf3 --frozen
 
 # ============================================================================
 # Pre-compile CUDA extensions to avoid JIT compilation at runtime


### PR DESCRIPTION
## Summary
- Combines the three separate `RUN pixi install` commands back into a single `RUN`
- Separate RUNs create overlay layers that duplicate shared conda packages (numpy, CUDA libs, etc.) across environments -- measured **~37 GB** (3 layers) vs **~14 GB** (1 layer)
- `ubuntu-latest` non-deterministically provisions runners with 72 GB or 145 GB disks. On 72 GB runners, the split-RUN approach exceeds available space during build

### Root cause investigation
The split was introduced in #204 for better layer caching. However, the three pixi environments share many conda packages, and overlay layers store full copies of files per layer. This ~23 GB overhead pushes the build past the disk limit on smaller runners.

Disk usage measured via `df -h` inside Docker build steps:

| Metric | Split RUN (3 layers) | Single RUN (1 layer) |
|--------|---------------------|---------------------|
| boltz | 8 GB | 8 GB |
| protenix | 12 GB (new layer) | 4 GB (shared pkgs deduped) |
| rf3 | 12 GB (new layer) | 2 GB (shared pkgs deduped) |
| **Total pixi disk** | **~37 GB** | **~14 GB** |

## Test plan
- [x] Verified split-RUN fails on 72 GB runners (jobs 70663224672, 70670232201)
- [x] Verified single-RUN disk usage via df -h debugging (job 70682099334)
- [x] Confirmed checkpoint image unchanged since March 25 (same SHA across all builds)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the deployment build process by consolidating multiple environment setup commands into a single optimized layer, resulting in improved build performance, reduced container image overhead, better dependency caching efficiency, and enhanced operational efficiency during containerization and deployment cycles while maintaining full functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->