### PR TITLE
fix: remap container paths to host paths in job_metadata.json

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -160,6 +160,24 @@ BAKED-IN CHECKPOINTS:
       --partial-diffusion-step N  Diffusion step to start from (default: 0)
       --loss-order N              L1 (1) or L2 (2) loss (default: 2)
 
+METADATA HOST PATH REMAPPING:
+    By default, job_metadata.json records container-internal paths (e.g.
+    /data/inputs/..., /data/results/...). To record host paths instead, pass
+    one or more of these environment variables:
+
+    Split mounts (-v $DATA:/data/inputs -v $RESULTS:/data/results):
+      SAMPLEWORKS_HOST_INPUT_DIR       Host path mounted at /data/inputs
+      SAMPLEWORKS_HOST_RESULTS_DIR    Host path mounted at /data/results
+
+    Single mount (-v /host/path:/data):
+      SAMPLEWORKS_HOST_DIR            Host path mounted at /data
+
+    Example (split mounts):
+      docker run -v /mnt/data:/data/inputs:ro -v /results:/data/results \
+        -e SAMPLEWORKS_HOST_INPUT_DIR=/mnt/data \
+        -e SAMPLEWORKS_HOST_RESULTS_DIR=/results \
+        sampleworks -e boltz run_grid_search.py ...
+
 PROTEINS CSV FORMAT:
     The --proteins CSV file must have the following columns:
       name        - Protein identifier

--- a/run_all_models.sh
+++ b/run_all_models.sh
@@ -55,6 +55,8 @@ docker run $DOCKER_OPTS \
     -v "$DATA_DIR:/data/inputs:ro" \
     -v "$RESULTS_DIR:/data/results" \
     -v "$MSA_CACHE_DIR:/root/.sampleworks/msa" \
+    -e SAMPLEWORKS_HOST_INPUT_DIR="$DATA_DIR" \
+    -e SAMPLEWORKS_HOST_RESULTS_DIR="$RESULTS_DIR" \
     diffuseproject/sampleworks:latest \
     -e boltz run_grid_search.py \
     --proteins "/data/inputs/proteins.csv" \
@@ -77,6 +79,8 @@ docker run $DOCKER_OPTS \
     -v "$DATA_DIR:/data/inputs:ro" \
     -v "$RESULTS_DIR:/data/results" \
     -v "$MSA_CACHE_DIR:/root/.sampleworks/msa" \
+    -e SAMPLEWORKS_HOST_INPUT_DIR="$DATA_DIR" \
+    -e SAMPLEWORKS_HOST_RESULTS_DIR="$RESULTS_DIR" \
     diffuseproject/sampleworks:latest \
     -e boltz run_grid_search.py \
     --proteins "/data/inputs/proteins.csv" \
@@ -99,6 +103,8 @@ docker run $DOCKER_OPTS \
     -v "$DATA_DIR:/data/inputs:ro" \
     -v "$RESULTS_DIR:/data/results" \
     -v "$MSA_CACHE_DIR:/root/.sampleworks/msa" \
+    -e SAMPLEWORKS_HOST_INPUT_DIR="$DATA_DIR" \
+    -e SAMPLEWORKS_HOST_RESULTS_DIR="$RESULTS_DIR" \
     diffuseproject/sampleworks:latest \
     -e rf3 run_grid_search.py \
     --proteins "/data/inputs/proteins.csv" \
@@ -120,6 +126,8 @@ docker run $DOCKER_OPTS \
     -v "$DATA_DIR:/data/inputs:ro" \
     -v "$RESULTS_DIR:/data/results" \
     -v "$MSA_CACHE_DIR:/root/.sampleworks/msa" \
+    -e SAMPLEWORKS_HOST_INPUT_DIR="$DATA_DIR" \
+    -e SAMPLEWORKS_HOST_RESULTS_DIR="$RESULTS_DIR" \
     diffuseproject/sampleworks:latest \
     -e protenix run_grid_search.py \
     --proteins "/data/inputs/proteins.csv" \

--- a/src/sampleworks/utils/guidance_script_arguments.py
+++ b/src/sampleworks/utils/guidance_script_arguments.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -50,6 +51,47 @@ def _resolve_checkpoint(model_key: str) -> str:
         )
 
     return resolved
+
+
+# ---------------------------------------------------------------------------
+# Container-to-host path remapping (for job_metadata.json serialization)
+# ---------------------------------------------------------------------------
+
+_ENV_VAR_MAPPINGS = [
+    # Order matters: most-specific container prefix first.
+    ("SAMPLEWORKS_HOST_INPUT_DIR", "/data/inputs"),
+    ("SAMPLEWORKS_HOST_RESULTS_DIR", "/data/results"),
+    ("SAMPLEWORKS_HOST_DIR", "/data"),
+]
+
+
+def _remap_container_path(path_str: str) -> str:
+    """Remap a container-internal path to its host equivalent.
+
+    Uses environment variables to determine the mapping:
+
+    * ``SAMPLEWORKS_HOST_INPUT_DIR``    replaces ``/data/inputs``
+    * ``SAMPLEWORKS_HOST_RESULTS_DIR`` replaces ``/data/results``
+    * ``SAMPLEWORKS_HOST_DIR``         replaces ``/data``  (fallback for single-mount setups)
+
+    When none of these env vars are set, the path is returned unchanged.
+    Paths that don't match any known container prefix (e.g. ``/checkpoints/``)
+    are also returned unchanged.
+    """
+    env_pairs: list[tuple[str, str]] = []
+    for env_var, container_prefix in _ENV_VAR_MAPPINGS:
+        host_dir = os.environ.get(env_var)
+        if host_dir is not None and host_dir.strip():
+            host_dir = host_dir.strip()
+            normalized_host = "/" if host_dir == "/" else host_dir.rstrip("/")
+            env_pairs.append((container_prefix.rstrip("/"), normalized_host))
+
+    for container_prefix, host_prefix in env_pairs:
+        if path_str == container_prefix or path_str.startswith(container_prefix + "/"):
+            result = host_prefix + path_str[len(container_prefix) :]
+            return result[1:] if result.startswith("//") else result
+
+    return path_str
 
 
 def get_checkpoint(args: argparse.Namespace) -> str | None:
@@ -327,10 +369,17 @@ class GuidanceConfig:
             self.ensemble_size = job.ensemble_size
 
     def as_dict(self) -> dict[str, Any]:
-        """Return a dictionary representation of the guidance config, converting Path to strings"""
+        """Return a dictionary representation of the guidance config, converting Path to strings.
+
+        When host-path env vars are set, container-internal paths are remapped
+        to their host equivalents so that
+        ``job_metadata.json`` is reproducible outside the container.
+        """
         output = self.__dict__.copy()
-        output["density"] = str(self.density)
-        output["structure"] = str(self.structure)
+        output["density"] = _remap_container_path(str(self.density))
+        output["structure"] = _remap_container_path(str(self.structure))
+        output["output_dir"] = _remap_container_path(str(self.output_dir))
+        output["log_path"] = _remap_container_path(str(self.log_path))
         return output
 
 

--- a/tests/utils/test_guidance_script_arguments.py
+++ b/tests/utils/test_guidance_script_arguments.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 from sampleworks.utils.guidance_constants import GuidanceType, StructurePredictor
 from sampleworks.utils.guidance_script_arguments import (
+    _remap_container_path,
     get_checkpoint,
     GuidanceConfig,
     JobConfig,
@@ -154,3 +155,176 @@ def test_validate_model_checkpoint_returns_resolved_path(model_wrapper_type, tmp
     validated = validate_model_checkpoint(model_wrapper_type, str(checkpoint))
 
     assert validated == str(checkpoint.resolve())
+
+
+# ============================================================================
+# _remap_container_path tests
+# ============================================================================
+
+
+def test_remap_noop_when_no_env_vars(monkeypatch):
+    for var in (
+        "SAMPLEWORKS_HOST_INPUT_DIR",
+        "SAMPLEWORKS_HOST_RESULTS_DIR",
+        "SAMPLEWORKS_HOST_DIR",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    assert _remap_container_path("/data/inputs/structure.cif") == "/data/inputs/structure.cif"
+    assert _remap_container_path("/data/results/output") == "/data/results/output"
+
+
+def test_remap_data_dir_env(monkeypatch):
+    monkeypatch.delenv("SAMPLEWORKS_HOST_RESULTS_DIR", raising=False)
+    monkeypatch.delenv("SAMPLEWORKS_HOST_DIR", raising=False)
+
+    monkeypatch.setenv("SAMPLEWORKS_HOST_INPUT_DIR", "/mnt/nfs/proteins")
+    assert _remap_container_path("/data/inputs/1abc.cif") == "/mnt/nfs/proteins/1abc.cif"
+    # results path should pass through (no env var for it)
+    assert _remap_container_path("/data/results/run1") == "/data/results/run1"
+
+
+def test_remap_results_dir_env(monkeypatch):
+    monkeypatch.delenv("SAMPLEWORKS_HOST_INPUT_DIR", raising=False)
+    monkeypatch.delenv("SAMPLEWORKS_HOST_DIR", raising=False)
+
+    monkeypatch.setenv("SAMPLEWORKS_HOST_RESULTS_DIR", "/results/exp1")
+    result = _remap_container_path("/data/results/protein/boltz2/run.log")
+    assert result == "/results/exp1/protein/boltz2/run.log"
+    # inputs path should pass through
+    assert _remap_container_path("/data/inputs/1abc.cif") == "/data/inputs/1abc.cif"
+
+
+def test_remap_catchall_dir_env(monkeypatch):
+    monkeypatch.delenv("SAMPLEWORKS_HOST_INPUT_DIR", raising=False)
+    monkeypatch.delenv("SAMPLEWORKS_HOST_RESULTS_DIR", raising=False)
+
+    monkeypatch.setenv("SAMPLEWORKS_HOST_DIR", "/mnt/storage")
+    assert _remap_container_path("/data/inputs/1abc.cif") == "/mnt/storage/inputs/1abc.cif"
+    assert _remap_container_path("/data/results/output") == "/mnt/storage/results/output"
+
+
+def test_remap_specific_env_takes_priority_over_catchall(monkeypatch):
+    monkeypatch.delenv("SAMPLEWORKS_HOST_RESULTS_DIR", raising=False)
+    monkeypatch.setenv("SAMPLEWORKS_HOST_INPUT_DIR", "/specific/data")
+    monkeypatch.setenv("SAMPLEWORKS_HOST_DIR", "/general")
+    assert _remap_container_path("/data/inputs/foo.cif") == "/specific/data/foo.cif"
+    # /data/results has no specific env var, so catch-all applies
+    assert _remap_container_path("/data/results/bar") == "/general/results/bar"
+
+
+def test_remap_leaves_checkpoint_unchanged(monkeypatch):
+    monkeypatch.setenv("SAMPLEWORKS_HOST_INPUT_DIR", "/host/data")
+    monkeypatch.setenv("SAMPLEWORKS_HOST_RESULTS_DIR", "/host/results")
+    monkeypatch.delenv("SAMPLEWORKS_HOST_DIR", raising=False)
+
+    assert _remap_container_path("/checkpoints/boltz2.ckpt") == "/checkpoints/boltz2.ckpt"
+
+
+def test_remap_trailing_slash_normalization(monkeypatch):
+    monkeypatch.delenv("SAMPLEWORKS_HOST_RESULTS_DIR", raising=False)
+    monkeypatch.delenv("SAMPLEWORKS_HOST_DIR", raising=False)
+
+    monkeypatch.setenv("SAMPLEWORKS_HOST_INPUT_DIR", "/mnt/data/")
+    assert _remap_container_path("/data/inputs/foo.cif") == "/mnt/data/foo.cif"
+
+
+def test_remap_exact_prefix_match(monkeypatch):
+    monkeypatch.delenv("SAMPLEWORKS_HOST_RESULTS_DIR", raising=False)
+    monkeypatch.delenv("SAMPLEWORKS_HOST_DIR", raising=False)
+
+    monkeypatch.setenv("SAMPLEWORKS_HOST_INPUT_DIR", "/mnt/data")
+    assert _remap_container_path("/data/inputs") == "/mnt/data"
+
+
+def test_remap_ignores_empty_env_var(monkeypatch):
+    monkeypatch.delenv("SAMPLEWORKS_HOST_RESULTS_DIR", raising=False)
+    monkeypatch.delenv("SAMPLEWORKS_HOST_DIR", raising=False)
+    monkeypatch.setenv("SAMPLEWORKS_HOST_INPUT_DIR", "")
+    assert _remap_container_path("/data/inputs/foo.cif") == "/data/inputs/foo.cif"
+
+
+def test_remap_whitespace_padded_env_var(monkeypatch):
+    monkeypatch.delenv("SAMPLEWORKS_HOST_RESULTS_DIR", raising=False)
+    monkeypatch.delenv("SAMPLEWORKS_HOST_DIR", raising=False)
+    monkeypatch.setenv("SAMPLEWORKS_HOST_INPUT_DIR", " /mnt/data ")
+    assert _remap_container_path("/data/inputs/foo.cif") == "/mnt/data/foo.cif"
+
+
+def test_remap_root_env_var(monkeypatch):
+    monkeypatch.delenv("SAMPLEWORKS_HOST_RESULTS_DIR", raising=False)
+    monkeypatch.delenv("SAMPLEWORKS_HOST_DIR", raising=False)
+    monkeypatch.setenv("SAMPLEWORKS_HOST_INPUT_DIR", "/")
+    assert _remap_container_path("/data/inputs/foo.cif") == "/foo.cif"
+    assert _remap_container_path("/data/inputs") == "/"
+
+
+# ============================================================================
+# as_dict path remapping tests
+# ============================================================================
+
+
+def test_as_dict_remaps_all_four_path_fields(monkeypatch):
+    monkeypatch.setenv("SAMPLEWORKS_HOST_INPUT_DIR", "/host/data")
+    monkeypatch.setenv("SAMPLEWORKS_HOST_RESULTS_DIR", "/host/results")
+    monkeypatch.delenv("SAMPLEWORKS_HOST_DIR", raising=False)
+
+    config = GuidanceConfig(
+        protein="1abc",
+        structure="/data/inputs/structures/1abc.cif",
+        density="/data/inputs/maps/1abc.ccp4",
+        model=StructurePredictor.BOLTZ_2,
+        guidance_type=GuidanceType.PURE_GUIDANCE,
+        log_path="/data/results/1abc/boltz2/run.log",
+        output_dir="/data/results/1abc/boltz2",
+    )
+    d = config.as_dict()
+    assert d["structure"] == "/host/data/structures/1abc.cif"
+    assert d["density"] == "/host/data/maps/1abc.ccp4"
+    assert d["output_dir"] == "/host/results/1abc/boltz2"
+    assert d["log_path"] == "/host/results/1abc/boltz2/run.log"
+    # Non-path fields unchanged
+    assert d["protein"] == "1abc"
+
+
+def test_as_dict_unchanged_when_no_env_vars(monkeypatch):
+    for var in (
+        "SAMPLEWORKS_HOST_INPUT_DIR",
+        "SAMPLEWORKS_HOST_RESULTS_DIR",
+        "SAMPLEWORKS_HOST_DIR",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    config = GuidanceConfig(
+        protein="1abc",
+        structure="/data/inputs/structures/1abc.cif",
+        density="/data/inputs/maps/1abc.ccp4",
+        model=StructurePredictor.BOLTZ_2,
+        guidance_type=GuidanceType.PURE_GUIDANCE,
+        log_path="/data/results/1abc/run.log",
+        output_dir="/data/results/1abc",
+    )
+    d = config.as_dict()
+    assert d["structure"] == "/data/inputs/structures/1abc.cif"
+    assert d["density"] == "/data/inputs/maps/1abc.ccp4"
+    assert d["output_dir"] == "/data/results/1abc"
+    assert d["log_path"] == "/data/results/1abc/run.log"
+
+
+def test_as_dict_remaps_with_catchall_host_dir(monkeypatch):
+    monkeypatch.delenv("SAMPLEWORKS_HOST_INPUT_DIR", raising=False)
+    monkeypatch.delenv("SAMPLEWORKS_HOST_RESULTS_DIR", raising=False)
+    monkeypatch.setenv("SAMPLEWORKS_HOST_DIR", "/mnt/storage")
+    config = GuidanceConfig(
+        protein="1abc",
+        structure="/data/inputs/structures/1abc.cif",
+        density="/data/inputs/maps/1abc.ccp4",
+        model=StructurePredictor.BOLTZ_2,
+        guidance_type=GuidanceType.PURE_GUIDANCE,
+        log_path="/data/results/1abc/run.log",
+        output_dir="/data/results/1abc",
+    )
+    d = config.as_dict()
+    assert d["structure"] == "/mnt/storage/inputs/structures/1abc.cif"
+    assert d["density"] == "/mnt/storage/inputs/maps/1abc.ccp4"
+    assert d["output_dir"] == "/mnt/storage/results/1abc"
+    assert d["log_path"] == "/mnt/storage/results/1abc/run.log"
+    assert d["protein"] == "1abc"


### PR DESCRIPTION
Closes #210

## Summary

- When guidance runs inside Docker, `job_metadata.json` recorded container-internal paths (`/data/inputs/...`, `/data/results/...`) instead of host paths, making it impossible to reproduce experiments from metadata alone
- Add `_remap_container_path()` in `GuidanceConfig.as_dict()` that substitutes container path prefixes with host paths using env vars
- Three env vars, checked in specificity order: `SAMPLEWORKS_HOST_INPUT_DIR` (`/data/inputs`), `SAMPLEWORKS_HOST_RESULTS_DIR` (`/data/results`), `SAMPLEWORKS_HOST_DIR` (`/data` catch-all for single mounts)
- Remapping only affects metadata serialization; runtime file I/O is unchanged
- When no env vars are set, behavior is identical to before

## Test plan

- [x] Unit tests for `_remap_container_path`: no-op without env vars, split mount remapping, catch-all remapping, specificity priority, checkpoint passthrough, trailing slash normalization, exact prefix match, empty env var handling
- [x] Integration tests for `as_dict()`: split mounts, catch-all, and no-env-var backward compat
- [x] `pixi run -e boltz-dev tests -- tests/utils/test_guidance_script_arguments.py -v` (39 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment variables to record host paths in job metadata: SAMPLEWORKS_HOST_INPUT_DIR, SAMPLEWORKS_HOST_RESULTS_DIR, or single SAMPLEWORKS_HOST_DIR.

* **Chores**
  * Docker run commands updated to pass these host-path environment variables into containers.

* **Documentation**
  * Help/usage output gained a METADATA HOST PATH REMAPPING section with examples.

* **Tests**
  * Added tests covering remapping behavior, precedence, normalization, and unaffected paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->