### PR TITLE
fix: replace deprecated builtin repo in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 repos:
-  - repo: builtin
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         exclude: \.(cif|pdb|ccp4|mtz|mrc)$


### PR DESCRIPTION
## Summary

- Replace `repo: builtin` with `repo: https://github.com/pre-commit/pre-commit-hooks` (rev v5.0.0) in `.pre-commit-config.yaml`
- The `builtin` syntax was removed in pre-commit 4.0, causing `InvalidConfigError` for anyone on pre-commit 4.x
- No behavior change -- same hooks (check-added-large-files, check-merge-conflict, check-yaml, end-of-file-fixer, trailing-whitespace)

## Test plan

- [x] `pre-commit run --all-files` passes with pre-commit 4.5.1