### PR TITLE
test(msa): add MSAManager unit tests (#178)

### DIFF
--- a/tests/utils/test_msa.py
+++ b/tests/utils/test_msa.py
@@ -1,0 +1,189 @@
+"""Tests for MSAManager and the MSA cache helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sampleworks.utils import msa as msa_module
+from sampleworks.utils.guidance_constants import StructurePredictor
+from sampleworks.utils.msa import _compute_msa, MSAManager
+
+
+# ============================================================================
+# _hash_arguments (test 5)
+# ============================================================================
+
+
+def test_hash_arguments_is_deterministic_and_input_sensitive():
+    data = {"A": "MKTAY", "B": "GGGAA"}
+    base = MSAManager._hash_arguments(data, "greedy")
+
+    assert base == MSAManager._hash_arguments({"A": "MKTAY", "B": "GGGAA"}, "greedy")
+
+    # Different sequence -> different hash.
+    assert base != MSAManager._hash_arguments({"A": "MKTAY", "B": "GGGAC"}, "greedy")
+    # Different pairing strategy -> different hash.
+    assert base != MSAManager._hash_arguments(data, "complete")
+    # Different value order -> different hash (hash is over tuple(values)).
+    assert base != MSAManager._hash_arguments({"B": "GGGAA", "A": "MKTAY"}, "greedy")
+
+
+# ============================================================================
+# __init__ cache directory handling (test 4)
+# ============================================================================
+
+
+def test_cache_dir_explicit_is_used(tmp_path: Path):
+    manager = MSAManager(msa_cache_dir=tmp_path)
+
+    assert manager.msa_dir == tmp_path
+    assert manager.msa_dir.exists()
+
+
+def test_cache_dir_explicit_string_converted_to_path(tmp_path: Path):
+    manager = MSAManager(msa_cache_dir=str(tmp_path))
+
+    assert isinstance(manager.msa_dir, Path)
+    assert manager.msa_dir == tmp_path
+
+
+def test_cache_dir_default_created_under_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # Redirect Path.home() so we don't pollute the real home directory.
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    manager = MSAManager(msa_cache_dir=None)
+
+    expected = tmp_path / ".sampleworks" / "msa"
+    assert manager.msa_dir == expected
+    assert expected.exists()
+
+
+# ============================================================================
+# get_msa -> _compute_msa wiring (test 1)
+# ============================================================================
+
+
+def _write_valid_cache_files(msa_dir: Path, hash_key: str, sequences: list[str]) -> None:
+    """Write a matching csv/a3m pair so _validate_msa_cache_contents passes."""
+    csv_lines = ["key,sequence"] + [f"-1,{s}" for s in sequences]
+    (msa_dir / f"{hash_key}_0.csv").write_text("\n".join(csv_lines))
+
+    a3m_lines = []
+    for i, s in enumerate(sequences):
+        a3m_lines.append(f">{hash_key}_0_{i}")
+        a3m_lines.append(s)
+    (msa_dir / f"{hash_key}_0.a3m").write_text("\n".join(a3m_lines) + "\n")
+
+
+def test_get_msa_calls_compute_when_cache_missing_and_skips_when_present(tmp_path: Path):
+    manager = MSAManager(msa_cache_dir=tmp_path)
+    data = {"A": "MKTAY"}
+    pairing = "greedy"
+    hash_key = MSAManager._hash_arguments(data, pairing)
+
+    def fake_compute(data_arg, target_id, msa_dir, *args, **kwargs):
+        _write_valid_cache_files(msa_dir, target_id, ["MKTAY", "MKTAC"])
+        return {name: msa_dir / f"{target_id}_0.csv" for name in data_arg}
+
+    with patch.object(msa_module, "_compute_msa", side_effect=fake_compute) as mock_compute:
+        result = manager.get_msa(data, pairing, structure_predictor=StructurePredictor.BOLTZ_2)
+
+        assert mock_compute.call_count == 1
+        # First positional arg is data, second is the hash used as target_id.
+        call_args = mock_compute.call_args
+        assert call_args.args[0] == data
+        assert call_args.args[1] == hash_key
+        assert call_args.args[2] == tmp_path
+
+        assert result == {"A": tmp_path / f"{hash_key}_0.csv"}
+        assert manager._api_calls == 1
+        assert manager._cache_hits == 0
+
+        # Second call should hit the cache and not invoke compute again.
+        mock_compute.reset_mock()
+        manager.get_msa(data, pairing, structure_predictor=StructurePredictor.BOLTZ_2)
+        mock_compute.assert_not_called()
+        assert manager._cache_hits == 1
+
+
+# ============================================================================
+# _compute_msa argument forwarding to run_mmseqs2 (test 2)
+# ============================================================================
+
+
+def test_compute_msa_calls_run_mmseqs2_with_correct_arguments(tmp_path: Path):
+    data = {"A": "AAA", "B": "BBB"}
+    target_id = "tgt"
+    fake_return = [">q\nAAA\n", ">q\nBBB\n"]
+
+    with patch.object(msa_module, "run_mmseqs2", return_value=fake_return) as mock_run:
+        _compute_msa(
+            data=data,
+            target_id=target_id,
+            msa_dir=tmp_path,
+            msa_server_url="https://example.org/api",
+            msa_pairing_strategy="greedy",
+            api_key_header="X-Custom-Key",
+            api_key_value="secret",
+        )
+
+    # With len(data) == 2, both the paired and unpaired branches should fire.
+    assert mock_run.call_count == 2
+
+    paired_call, unpaired_call = mock_run.call_args_list
+
+    # Paired call.
+    assert paired_call.args[0] == ["AAA", "BBB"]
+    assert paired_call.args[1] == str(tmp_path / f"{target_id}_paired_tmp")
+    assert paired_call.kwargs["use_pairing"] is True
+    assert paired_call.kwargs["use_env"] is True
+    assert paired_call.kwargs["host_url"] == "https://example.org/api"
+    assert paired_call.kwargs["pairing_strategy"] == "greedy"
+    assert paired_call.kwargs["auth_headers"] == {
+        "Content-Type": "application/json",
+        "X-Custom-Key": "secret",
+    }
+
+    # Unpaired call.
+    assert unpaired_call.args[0] == ["AAA", "BBB"]
+    assert unpaired_call.args[1] == str(tmp_path / f"{target_id}_unpaired_tmp")
+    assert unpaired_call.kwargs["use_pairing"] is False
+    assert unpaired_call.kwargs["host_url"] == "https://example.org/api"
+    assert unpaired_call.kwargs["pairing_strategy"] == "greedy"
+
+
+# ============================================================================
+# _compute_msa file output consistency (test 3)
+# ============================================================================
+
+
+def test_compute_msa_writes_matching_csv_and_a3m(tmp_path: Path):
+    data = {"chainA": "MKTAY"}
+    target_id = "thehash"
+    # FASTA-style: alternating header / sequence lines. _compute_msa parses [1::2].
+    fake_return = [">query\nMKTAY\n>hit1\nMKTAC\n>hit2\nMKTAG\n"]
+
+    with patch.object(msa_module, "run_mmseqs2", return_value=fake_return):
+        _compute_msa(
+            data=data,
+            target_id=target_id,
+            msa_dir=tmp_path,
+            msa_server_url="https://example.org/api",
+            msa_pairing_strategy="greedy",
+        )
+
+    csv_path = tmp_path / f"{target_id}_0.csv"
+    a3m_path = tmp_path / f"{target_id}_0.a3m"
+    assert csv_path.exists()
+    assert a3m_path.exists()
+
+    csv_lines = csv_path.read_text().splitlines()
+    assert csv_lines[0] == "key,sequence"
+    csv_sequences = [line.split(",", 1)[1] for line in csv_lines[1:]]
+
+    a3m_lines = a3m_path.read_text().splitlines()
+    a3m_sequences = [line for i, line in enumerate(a3m_lines) if i % 2 == 1]
+
+    assert csv_sequences == a3m_sequences == ["MKTAY", "MKTAC", "MKTAG"]

--- a/tests/utils/test_msa.py
+++ b/tests/utils/test_msa.py
@@ -146,12 +146,17 @@ def test_compute_msa_calls_run_mmseqs2_with_correct_arguments(tmp_path: Path):
         "X-Custom-Key": "secret",
     }
 
-    # Unpaired call.
+    # Unpaired call: should forward the same env/auth flags as the paired call.
     assert unpaired_call.args[0] == ["AAA", "BBB"]
     assert unpaired_call.args[1] == str(tmp_path / f"{target_id}_unpaired_tmp")
     assert unpaired_call.kwargs["use_pairing"] is False
+    assert unpaired_call.kwargs["use_env"] is True
     assert unpaired_call.kwargs["host_url"] == "https://example.org/api"
     assert unpaired_call.kwargs["pairing_strategy"] == "greedy"
+    assert unpaired_call.kwargs["auth_headers"] == {
+        "Content-Type": "application/json",
+        "X-Custom-Key": "secret",
+    }
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
Adds [tests/utils/test_msa.py](tests/utils/test_msa.py) covering the five tests requested in #178:

1. `_hash_arguments` is deterministic for identical inputs and sensitive to sequence content, pairing strategy, and value order.
2. Explicit `msa_cache_dir` is used (both `Path` and `str` forms); default `None` creates `~/.sampleworks/msa` (with `Path.home` monkeypatched to `tmp_path` so the real home is untouched).
3. `get_msa` calls `_compute_msa` when cache files are missing, and skips it on the second call when they exist. Cache-hit/api-call counters are asserted.
4. `_compute_msa` forwards the expected arguments to `run_mmseqs2` for both the paired and unpaired branches (2-sequence input so both fire), including `auth_headers` built from `api_key_header` / `api_key_value`.
5. `_compute_msa` writes matching `.csv` and `.a3m` files: the second column of the csv equals the odd (sequence) lines of the a3m.

## Notes
- Mocks patch `sampleworks.utils.msa.run_mmseqs2` and `sampleworks.utils.msa._compute_msa` (not the source modules) so the actual call sites in `msa.py` are intercepted — `run_mmseqs2` is imported at module load, and `_compute_msa` is module-level.
- Test 3 uses a `side_effect` that writes a valid csv/a3m pair so the unconditional `_validate_msa_cache_contents` call inside `get_msa` passes, doubling as a smoke check that the cache layout `_compute_msa` writes matches what `get_msa` expects.
- Protenix branch is intentionally not tested per the issue; no new dependency on `PROTENIX_AVAILABLE`.

## Test plan
- [x] `pixi run -e boltz-dev python3 -m pytest tests/utils/test_msa.py -v` → 7 passed in 0.03s
- [x] `pixi run -e boltz-dev all-tests` → 748 passed, 509 skipped, no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite for MSA utilities covering deterministic input hashing, cache behavior and directory initialization, correct triggering of MSA computation when cache entries are missing, and subsequent cache hits. Also validates integration with the external alignment tool (correct call patterns and flags), temp-directory usage, and output consistency between generated alignment files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->