### PR TITLE
feat(diffuse): add ACTL-native Sampleworks wrappers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,8 +100,9 @@ COPY pyproject.toml pixi.lock ./
 COPY src/ ./src/
 COPY scripts/ ./scripts/
 COPY run_grid_search.py ./
+COPY *_actl.sh /usr/local/bin/
 COPY docker-entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/*_actl.sh
 
 # ============================================================================
 # Bake in model checkpoints from pre-built base image on Docker Hub

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,6 +4,8 @@
 # Usage:
 #   docker run sampleworks -e <pixi_env> <script> [args...]
 #   docker run sampleworks -e boltz run_grid_search.py --proteins /data/proteins.csv ...
+#   docker run sampleworks run_grid_search_actl.sh --model rf3 --proteins /data/proteins.csv
+#   docker run sampleworks run_all_models_actl.sh  # native ACTL/Kubernetes run
 #   docker run sampleworks bash  # interactive shell
 #
 # Available pixi environments: boltz, protenix, rf3
@@ -29,6 +31,7 @@ Sampleworks - Protein structure prediction with diffusion model guidance
 
 USAGE:
     docker run --gpus all --shm-size=16g sampleworks -e <environment> <script> [arguments...]
+    docker run sampleworks run_all_models_actl.sh
     docker run sampleworks bash
     docker run sampleworks --help
 
@@ -39,6 +42,9 @@ OPTIONS:
     -e, --env <env>     Pixi environment to use (boltz, protenix, rf3)
     -h, --help          Show this help message
     bash                Start an interactive shell
+    run_grid_search_actl.sh
+                        Run run_grid_search.py natively inside this container
+    *_actl.sh           Run one of the bundled ACTL/Kubernetes-native wrappers
 
 ENVIRONMENTS:
     boltz       For boltz1 and boltz2 models
@@ -100,6 +106,13 @@ EXAMPLES:
 
     # Interactive shell
     docker run --gpus all --shm-size=16g -it sampleworks bash
+
+    # ACTL/Kubernetes-native all-model run. No Docker is started inside the container.
+    docker run --gpus all --shm-size=16g -v /data:/data sampleworks run_all_models_actl.sh
+
+    # ACTL/Kubernetes-native generic grid search launcher.
+    docker run --gpus all --shm-size=16g -v /data:/data sampleworks \
+      run_grid_search_actl.sh --model rf3 --proteins /data/proteins.csv --output-dir /data/results
 
     # Run a custom script
     docker run --gpus all --shm-size=16g -v /data:/data sampleworks \
@@ -206,6 +219,12 @@ if [ "$1" = "bash" ] || [ "$1" = "sh" ]; then
     exec "$@"
 fi
 
+# ACTL/Kubernetes-native runners are intended to run inside the already-started
+# sampleworks container and must not launch Docker-in-Docker.
+if [[ "$1" == *_actl.sh ]]; then
+    exec "$@"
+fi
+
 # Parse -e/--env argument
 ENV=""
 while [[ $# -gt 0 ]]; do
@@ -220,9 +239,10 @@ while [[ $# -gt 0 ]]; do
             break
             ;;
         *)
-            echo "Error: First argument must be -e <environment>, bash, or --help"
+            echo "Error: First argument must be -e <environment>, *_actl.sh, bash, or --help"
             echo ""
             echo "Usage: docker run sampleworks -e <env> <script> [args...]"
+            echo "       docker run sampleworks run_all_models_actl.sh"
             echo "       docker run sampleworks bash"
             echo "       docker run sampleworks --help"
             exit 1
@@ -239,6 +259,7 @@ if [[ -z "$ENV" ]]; then
     echo "Examples:"
     echo "  docker run sampleworks -e boltz run_grid_search.py --proteins /data/proteins.csv"
     echo "  docker run sampleworks -e rf3 run_grid_search.py --help"
+    echo "  docker run sampleworks run_all_models_actl.sh"
     echo "  docker run sampleworks bash"
     exit 1
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,13 +15,13 @@
 #   docker run --gpus all -v /data:/data sampleworks \
 #     -e rf3 run_grid_search.py \
 #     --proteins /data/proteins.csv \
-#     --models rf3 \
+#     --model rf3 \
 #     --scalers pure_guidance \
 #     --ensemble-sizes "1 4" \
 #     --gradient-weights "0.1 0.2" \
 #     --output-dir /data/results \
 #     --use-tweedie \
-#     --rf3-checkpoint /data/checkpoints/rf3.ckpt
+#     --model-checkpoint /data/checkpoints/rf3.ckpt
 
 set -e
 
@@ -56,7 +56,7 @@ EXAMPLES:
     docker run --gpus all --shm-size=16g -v /data:/data sampleworks \
       -e rf3 run_grid_search.py \
       --proteins /data/proteins.csv \
-      --models rf3 \
+      --model rf3 \
       --scalers pure_guidance \
       --ensemble-sizes "1 4" \
       --gradient-weights "0.1 0.2" \
@@ -65,44 +65,44 @@ EXAMPLES:
       --gradient-normalization \
       --augmentation \
       --align-to-input \
-      --rf3-checkpoint /data/checkpoints/rf3_foundry_01_24_latest.ckpt
+      --model-checkpoint /data/checkpoints/rf3_foundry_01_24_latest.ckpt
 
     # Run grid search with Boltz1 model
     docker run --gpus all --shm-size=16g -v /data:/data sampleworks \
       -e boltz run_grid_search.py \
       --proteins /data/proteins.csv \
-      --models boltz1 \
+      --model boltz1 \
       --scalers pure_guidance \
       --ensemble-sizes "1 4" \
       --gradient-weights "0.1 0.2" \
       --output-dir /data/results \
       --use-tweedie \
-      --boltz1-checkpoint /data/checkpoints/boltz1_conf.ckpt
+      --model-checkpoint /data/checkpoints/boltz1_conf.ckpt
 
     # Run grid search with Boltz2 model
     docker run --gpus all --shm-size=16g -v /data:/data sampleworks \
       -e boltz run_grid_search.py \
       --proteins /data/proteins.csv \
-      --models boltz2 \
+      --model boltz2 \
       --scalers pure_guidance \
-      --methods "X-RAY DIFFRACTION" \
+      --method "X-RAY DIFFRACTION" \
       --ensemble-sizes "1 4" \
       --gradient-weights "0.1 0.2" \
       --output-dir /data/results \
       --use-tweedie \
-      --boltz2-checkpoint /data/checkpoints/boltz2_conf.ckpt
+      --model-checkpoint /data/checkpoints/boltz2_conf.ckpt
 
     # Run grid search with Protenix model
     docker run --gpus all --shm-size=16g -v /data:/data sampleworks \
       -e protenix run_grid_search.py \
       --proteins /data/proteins.csv \
-      --models protenix \
+      --model protenix \
       --scalers pure_guidance \
       --ensemble-sizes "1 4" \
       --gradient-weights "0.1 0.2" \
       --output-dir /data/results \
       --use-tweedie \
-      --protenix-checkpoint /data/checkpoints/protenix_base_default_v0.5.0.pt
+      --model-checkpoint /data/checkpoints/protenix_base_default_v0.5.0.pt
 
     # Interactive shell
     docker run --gpus all --shm-size=16g -it sampleworks bash
@@ -126,7 +126,7 @@ GRID SEARCH ARGUMENTS (run_grid_search.py):
       --proteins FILE             CSV file with columns: structure,density,resolution,name
 
     Model selection:
-      --models MODEL              Model to use (boltz1, boltz2, protenix, rf3)
+      --model MODEL               Model to use (boltz1, boltz2, protenix, rf3)
                                   Note: Only one model per run currently supported
 
     Guidance configuration:
@@ -149,11 +149,8 @@ GRID SEARCH ARGUMENTS (run_grid_search.py):
       --max-parallel N            Max parallel jobs (default: auto = number of GPUs)
 
     Model-specific options:
-      --boltz1-checkpoint PATH    Path to Boltz1 checkpoint (default: /checkpoints/boltz1_conf.ckpt - BAKED IN)
-      --boltz2-checkpoint PATH    Path to Boltz2 checkpoint (default: /checkpoints/boltz2_conf.ckpt - BAKED IN)
-      --protenix-checkpoint PATH  Path to Protenix checkpoint
-      --rf3-checkpoint PATH       Path to RF3 checkpoint
-      --methods METHOD            Boltz2 sampling method (default: "X-RAY DIFFRACTION")
+      --model-checkpoint PATH     Path to model checkpoint
+      --method METHOD             Boltz2 sampling method (default: "X-RAY DIFFRACTION")
 
 BAKED-IN CHECKPOINTS:
     The following checkpoints are pre-installed in the image:

--- a/rf3_partial_occ_sweep_chiral_off_actl.sh
+++ b/rf3_partial_occ_sweep_chiral_off_actl.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Run RF3 occ-sweep partial grid search with chiral features disabled.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_GRID_SEARCH_ACTL="${RUN_GRID_SEARCH_ACTL:-$SCRIPT_DIR/run_grid_search_actl.sh}"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    cat << 'EOF'
+Usage: rf3_partial_occ_sweep_chiral_off_actl.sh
+
+Environment overrides: DATA_DIR, RESULTS_DIR, MSA_CACHE_DIR, PROTEINS_CSV, GPU_DEVICES, RF3_CHECKPOINT
+EOF
+    exit 0
+fi
+
+DATA_DIR="${DATA_DIR:-/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps}"
+RESULTS_DIR="${RESULTS_DIR:-/data/sampleworks-exp/occ_sweep/grid_search_results_rf3_chiral_off}"
+MSA_CACHE_DIR="${MSA_CACHE_DIR:-${HOME}/sampleworks-exp/msa_cache}"
+PROTEINS_CSV="${PROTEINS_CSV:-$DATA_DIR/proteins.csv}"
+GPU_DEVICES="${GPU_DEVICES:-5}"
+
+if [[ ! -f "$PROTEINS_CSV" ]]; then
+    echo "Error: proteins CSV not found: $PROTEINS_CSV" >&2
+    exit 1
+fi
+
+mkdir -p "$RESULTS_DIR" "$MSA_CACHE_DIR"
+
+echo "[$(date)] Starting RF3 chiral-off occ-sweep run on GPUs $GPU_DEVICES"
+CUDA_VISIBLE_DEVICES="$GPU_DEVICES" "$RUN_GRID_SEARCH_ACTL" \
+    --model rf3 \
+    --proteins "$PROTEINS_CSV" \
+    --scalers pure_guidance \
+    --partial-diffusion-step 120 \
+    --ensemble-sizes "8" \
+    --gradient-weights "0.0 0.005 0.01 0.02 0.035 0.05 0.1 0.2 0.35 0.5" \
+    --gradient-normalization --augmentation --align-to-input \
+    --output-dir "$RESULTS_DIR" \
+    --force-all \
+    --disable-chiral-features \
+    --model-checkpoint "${RF3_CHECKPOINT:-/checkpoints/rf3_foundry_01_24_latest.ckpt}" \
+    2>&1 | tee "$RESULTS_DIR/rf3_partial_run_occ_sweep_chiral_off.log"
+
+echo "[$(date)] RF3 job completed."

--- a/rf3_partial_occ_sweep_fixed_actl.sh
+++ b/rf3_partial_occ_sweep_fixed_actl.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Alias for the fixed occ-sweep RF3 ACTL run, matching the remote wrapper name.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+RESULTS_DIR="${RESULTS_DIR:-/data/sampleworks-exp/occ_sweep/grid_search_results}" \
+MSA_CACHE_DIR="${MSA_CACHE_DIR:-/data/sampleworks-exp/msa_cache}" \
+exec "$SCRIPT_DIR/run_rf3_partial_fixed_actl.sh" "$@"

--- a/run_all_models_actl.sh
+++ b/run_all_models_actl.sh
@@ -70,9 +70,12 @@ start_grid_search() {
     shift 4
 
     echo "[$(date)] Starting $name on GPUs $gpu_devices"
-    CUDA_VISIBLE_DEVICES="$gpu_devices" \
-        pixi run -e "$pixi_env" python /app/run_grid_search.py "$@" \
-        2>&1 | tee "$log_file" &
+    (
+        set -o pipefail
+        CUDA_VISIBLE_DEVICES="$gpu_devices" \
+            pixi run -e "$pixi_env" python /app/run_grid_search.py "$@" \
+            2>&1 | tee "$log_file"
+    ) &
     PIDS+=("$!")
     NAMES+=("$name")
     echo "[$(date)] $name job started (PID: ${PIDS[-1]})"
@@ -87,7 +90,7 @@ start_grid_search "Boltz2 X-ray" "0,1" "boltz" "$RESULTS_DIR/boltz2_xrd_run.log"
     --ensemble-sizes "8" \
     --gradient-weights "0.0 0.05 0.1 0.2 0.35 0.5" \
     --gradient-normalization --augmentation --align-to-input \
-    --output-dir "$RESULTS_DIR"
+    --output-dir "$RESULTS_DIR/boltz2_xrd"
 
 start_grid_search "Boltz2 MD" "2,3" "boltz" "$RESULTS_DIR/boltz2_md_run.log" \
     --proteins "$PROTEINS_CSV" \
@@ -98,7 +101,7 @@ start_grid_search "Boltz2 MD" "2,3" "boltz" "$RESULTS_DIR/boltz2_md_run.log" \
     --ensemble-sizes "8" \
     --gradient-weights "0.0 0.05 0.1 0.2 0.35 0.5" \
     --gradient-normalization --augmentation --align-to-input \
-    --output-dir "$RESULTS_DIR"
+    --output-dir "$RESULTS_DIR/boltz2_md"
 
 start_grid_search "RosettaFold3" "4,5" "rf3" "$RESULTS_DIR/rf3_run.log" \
     --proteins "$PROTEINS_CSV" \
@@ -108,7 +111,7 @@ start_grid_search "RosettaFold3" "4,5" "rf3" "$RESULTS_DIR/rf3_run.log" \
     --ensemble-sizes "8" \
     --gradient-weights "0.0 0.005 0.01 0.02 0.035 0.05 0.1" \
     --gradient-normalization --augmentation --align-to-input \
-    --output-dir "$RESULTS_DIR"
+    --output-dir "$RESULTS_DIR/rf3"
 
 start_grid_search "Protenix" "6,7" "protenix" "$RESULTS_DIR/protenix_run.log" \
     --proteins "$PROTEINS_CSV" \
@@ -118,7 +121,7 @@ start_grid_search "Protenix" "6,7" "protenix" "$RESULTS_DIR/protenix_run.log" \
     --ensemble-sizes "8" \
     --gradient-weights "0.0 0.05 0.1 0.2 0.35 0.5" \
     --gradient-normalization --augmentation --align-to-input \
-    --output-dir "$RESULTS_DIR"
+    --output-dir "$RESULTS_DIR/protenix"
 
 echo ""
 echo "=========================================="

--- a/run_all_models_actl.sh
+++ b/run_all_models_actl.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Run all 4 Sampleworks model grid searches in parallel inside the current container.
+#
+# This is the ACTL/Kubernetes-native version of run_all_models.sh. It intentionally
+# does not run Docker; launch/connect to the sampleworks image first, then run this
+# script in that container.
+#
+# Usage:
+#   run_all_models_actl.sh
+#
+# Environment overrides:
+#   DATA_DIR       Input directory containing proteins.csv (default: /data/input)
+#   RESULTS_DIR    Output directory (default: /data/results)
+#   MSA_CACHE_DIR  MSA cache directory (default: /root/.sampleworks/msa)
+
+set -euo pipefail
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    cat << 'EOF'
+Run all 4 Sampleworks model grid searches in parallel inside the current container.
+
+Usage:
+  run_all_models_actl.sh
+
+Environment overrides:
+  DATA_DIR       Input directory containing proteins.csv (default: /data/input)
+  RESULTS_DIR    Output directory (default: /data/results)
+  MSA_CACHE_DIR  MSA cache directory (default: /root/.sampleworks/msa)
+  PROTEINS_CSV   Explicit proteins CSV path (default: $DATA_DIR/proteins.csv)
+EOF
+    exit 0
+fi
+
+DATA_DIR="${DATA_DIR:-/data/input}"
+RESULTS_DIR="${RESULTS_DIR:-/data/results}"
+MSA_CACHE_DIR="${MSA_CACHE_DIR:-/root/.sampleworks/msa}"
+PROTEINS_CSV="${PROTEINS_CSV:-$DATA_DIR/proteins.csv}"
+
+if [[ ! -f "$PROTEINS_CSV" ]]; then
+    echo "Error: proteins CSV not found: $PROTEINS_CSV" >&2
+    echo "Set DATA_DIR or PROTEINS_CSV to the mounted Sampleworks input path." >&2
+    exit 1
+fi
+
+mkdir -p "$RESULTS_DIR" "$MSA_CACHE_DIR"
+
+echo "=========================================="
+echo "Starting all model grid searches natively (4 jobs x 2 GPUs)"
+echo "Data: $DATA_DIR"
+echo "Proteins CSV: $PROTEINS_CSV"
+echo "Results: $RESULTS_DIR"
+echo "MSA Cache: $MSA_CACHE_DIR"
+echo "Checkpoints: BAKED INTO IMAGE (with mount fallback)"
+echo ""
+echo "Models:"
+echo "  - Boltz2 X-ray (GPUs 0,1)"
+echo "  - Boltz2 MD    (GPUs 2,3)"
+echo "  - RF3          (GPUs 4,5)"
+echo "  - Protenix     (GPUs 6,7)"
+echo "=========================================="
+
+PIDS=()
+NAMES=()
+
+start_grid_search() {
+    local name="$1"
+    local gpu_devices="$2"
+    local pixi_env="$3"
+    local log_file="$4"
+    shift 4
+
+    echo "[$(date)] Starting $name on GPUs $gpu_devices"
+    CUDA_VISIBLE_DEVICES="$gpu_devices" \
+        pixi run -e "$pixi_env" python /app/run_grid_search.py "$@" \
+        2>&1 | tee "$log_file" &
+    PIDS+=("$!")
+    NAMES+=("$name")
+    echo "[$(date)] $name job started (PID: ${PIDS[-1]})"
+}
+
+start_grid_search "Boltz2 X-ray" "0,1" "boltz" "$RESULTS_DIR/boltz2_xrd_run.log" \
+    --proteins "$PROTEINS_CSV" \
+    --model boltz2 \
+    --method "X-RAY DIFFRACTION" \
+    --scalers pure_guidance \
+    --partial-diffusion-step 120 \
+    --ensemble-sizes "8" \
+    --gradient-weights "0.0 0.05 0.1 0.2 0.35 0.5" \
+    --gradient-normalization --augmentation --align-to-input \
+    --output-dir "$RESULTS_DIR"
+
+start_grid_search "Boltz2 MD" "2,3" "boltz" "$RESULTS_DIR/boltz2_md_run.log" \
+    --proteins "$PROTEINS_CSV" \
+    --model boltz2 \
+    --method "MD" \
+    --scalers pure_guidance \
+    --partial-diffusion-step 120 \
+    --ensemble-sizes "8" \
+    --gradient-weights "0.0 0.05 0.1 0.2 0.35 0.5" \
+    --gradient-normalization --augmentation --align-to-input \
+    --output-dir "$RESULTS_DIR"
+
+start_grid_search "RosettaFold3" "4,5" "rf3" "$RESULTS_DIR/rf3_run.log" \
+    --proteins "$PROTEINS_CSV" \
+    --model rf3 \
+    --partial-diffusion-step 120 \
+    --scalers pure_guidance \
+    --ensemble-sizes "8" \
+    --gradient-weights "0.0 0.005 0.01 0.02 0.035 0.05 0.1" \
+    --gradient-normalization --augmentation --align-to-input \
+    --output-dir "$RESULTS_DIR"
+
+start_grid_search "Protenix" "6,7" "protenix" "$RESULTS_DIR/protenix_run.log" \
+    --proteins "$PROTEINS_CSV" \
+    --model protenix \
+    --scalers pure_guidance \
+    --partial-diffusion-step 120 \
+    --ensemble-sizes "8" \
+    --gradient-weights "0.0 0.05 0.1 0.2 0.35 0.5" \
+    --gradient-normalization --augmentation --align-to-input \
+    --output-dir "$RESULTS_DIR"
+
+echo ""
+echo "=========================================="
+echo "All 4 jobs launched! PIDs: ${PIDS[*]}"
+echo "Logs:"
+echo "  - $RESULTS_DIR/boltz2_xrd_run.log"
+echo "  - $RESULTS_DIR/boltz2_md_run.log"
+echo "  - $RESULTS_DIR/rf3_run.log"
+echo "  - $RESULTS_DIR/protenix_run.log"
+echo ""
+echo "Monitor GPU usage: nvidia-smi -l 1"
+echo "Waiting for all jobs to complete..."
+echo "=========================================="
+
+failed=0
+for index in "${!PIDS[@]}"; do
+    if wait "${PIDS[$index]}"; then
+        echo "[$(date)] ${NAMES[$index]} completed successfully"
+    else
+        status=$?
+        echo "[$(date)] ${NAMES[$index]} failed with exit code $status" >&2
+        failed=1
+    fi
+done
+
+echo ""
+echo "=========================================="
+if [[ "$failed" -eq 0 ]]; then
+    echo "[$(date)] All jobs completed successfully!"
+else
+    echo "[$(date)] One or more jobs failed. Check logs above."
+fi
+echo "=========================================="
+
+exit "$failed"

--- a/run_all_models_mdc_actl.sh
+++ b/run_all_models_mdc_actl.sh
@@ -86,7 +86,10 @@ start_grid_search() {
     shift 3
 
     echo "[$(date)] Starting $name on GPUs $gpu_devices"
-    CUDA_VISIBLE_DEVICES="$gpu_devices" "$RUN_GRID_SEARCH_ACTL" "$@" 2>&1 | tee "$log_file" &
+    (
+        set -o pipefail
+        CUDA_VISIBLE_DEVICES="$gpu_devices" "$RUN_GRID_SEARCH_ACTL" "$@" 2>&1 | tee "$log_file"
+    ) &
     PIDS+=("$!")
     NAMES+=("$name")
     echo "[$(date)] $name job started (PID: ${PIDS[-1]})"
@@ -97,7 +100,7 @@ if [[ "$RUN_BOLTZ2_XRD" == true ]]; then
         --model boltz2 --method "X-RAY DIFFRACTION" --proteins "$PROTEINS_CSV" \
         --scalers pure_guidance --partial-diffusion-step 120 --ensemble-sizes "8" \
         --gradient-weights "0.1 0.2 0.5" --gradient-normalization --augmentation \
-        --align-to-input --output-dir "$RESULTS_DIR"
+        --align-to-input --output-dir "$RESULTS_DIR/boltz2_xrd"
 fi
 
 if [[ "$RUN_BOLTZ2_MD" == true ]]; then
@@ -105,21 +108,21 @@ if [[ "$RUN_BOLTZ2_MD" == true ]]; then
         --model boltz2 --method "MD" --proteins "$PROTEINS_CSV" \
         --scalers pure_guidance --partial-diffusion-step 120 --ensemble-sizes "8" \
         --gradient-weights "0.1 0.2 0.5" --gradient-normalization --augmentation \
-        --align-to-input --output-dir "$RESULTS_DIR"
+        --align-to-input --output-dir "$RESULTS_DIR/boltz2_md"
 fi
 
 if [[ "$RUN_RF3" == true ]]; then
     start_grid_search "RosettaFold3" "4,5" "$RESULTS_DIR/rf3_run.log" \
         --model rf3 --proteins "$PROTEINS_CSV" --scalers pure_guidance \
         --ensemble-sizes "8" --gradient-weights "0.01 0.02 0.05" \
-        --gradient-normalization --augmentation --align-to-input --output-dir "$RESULTS_DIR"
+        --gradient-normalization --augmentation --align-to-input --output-dir "$RESULTS_DIR/rf3"
 fi
 
 if [[ "$RUN_PROTENIX" == true ]]; then
     start_grid_search "Protenix" "6,7" "$RESULTS_DIR/protenix_run.log" \
         --model protenix --proteins "$PROTEINS_CSV" --scalers pure_guidance \
         --partial-diffusion-step 120 --ensemble-sizes "8" --gradient-weights "0.1 0.2 0.5" \
-        --gradient-normalization --augmentation --align-to-input --output-dir "$RESULTS_DIR"
+        --gradient-normalization --augmentation --align-to-input --output-dir "$RESULTS_DIR/protenix"
 fi
 
 if [[ ${#PIDS[@]} -eq 0 ]]; then

--- a/run_all_models_mdc_actl.sh
+++ b/run_all_models_mdc_actl.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Run selected Sampleworks model grid searches inside the current container.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_GRID_SEARCH_ACTL="${RUN_GRID_SEARCH_ACTL:-$SCRIPT_DIR/run_grid_search_actl.sh}"
+
+show_help() {
+    cat << 'EOF'
+Usage: run_all_models_mdc_actl.sh [OPTIONS]
+
+Options:
+  --boltz2-xrd    Run Boltz2 with X-ray diffraction (GPUs 0,1)
+  --boltz2-md     Run Boltz2 with MD (GPUs 2,3)
+  --rf3           Run RosettaFold3 (GPUs 4,5)
+  --protenix      Run Protenix (GPUs 6,7)
+  --all           Run all models (default if no args)
+  --help          Show this help message
+
+Environment overrides:
+  DATA_DIR       Input directory containing proteins.csv
+  RESULTS_DIR    Output directory
+  MSA_CACHE_DIR  MSA cache directory
+  PROTEINS_CSV   Explicit proteins CSV path
+EOF
+}
+
+DATA_DIR="${DATA_DIR:-/mnt/diffuse-private/raw/sampleworks/initial_dataset_40}"
+RESULTS_DIR="${RESULTS_DIR:-${HOME}/sampleworks-exp/grid_search_results}"
+MSA_CACHE_DIR="${MSA_CACHE_DIR:-${HOME}/sampleworks-exp/msa_cache}"
+PROTEINS_CSV="${PROTEINS_CSV:-$DATA_DIR/proteins.csv}"
+
+RUN_BOLTZ2_XRD=false
+RUN_BOLTZ2_MD=false
+RUN_RF3=false
+RUN_PROTENIX=false
+
+if [[ $# -eq 0 ]]; then
+    RUN_BOLTZ2_XRD=true
+    RUN_BOLTZ2_MD=true
+    RUN_RF3=true
+    RUN_PROTENIX=true
+else
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --boltz2-xrd|--boltz-xrd|--boltz2_xrd) RUN_BOLTZ2_XRD=true ;;
+            --boltz2-md|--boltz-md|--boltz2_md) RUN_BOLTZ2_MD=true ;;
+            --rf3|--rosettafold3|--rosettafold) RUN_RF3=true ;;
+            --protenix) RUN_PROTENIX=true ;;
+            --all) RUN_BOLTZ2_XRD=true; RUN_BOLTZ2_MD=true; RUN_RF3=true; RUN_PROTENIX=true ;;
+            --help|-h) show_help; exit 0 ;;
+            *) echo "Unknown option: $1" >&2; echo "Use --help for usage." >&2; exit 1 ;;
+        esac
+        shift
+    done
+fi
+
+if [[ ! -f "$PROTEINS_CSV" ]]; then
+    echo "Error: proteins CSV not found: $PROTEINS_CSV" >&2
+    exit 1
+fi
+
+mkdir -p "$RESULTS_DIR" "$MSA_CACHE_DIR"
+
+echo "=========================================="
+echo "Starting selected model grid searches natively"
+echo "Data: $DATA_DIR"
+echo "Proteins CSV: $PROTEINS_CSV"
+echo "Results: $RESULTS_DIR"
+echo "MSA Cache: $MSA_CACHE_DIR"
+echo "Models to run:"
+[[ "$RUN_BOLTZ2_XRD" == true ]] && echo "  - Boltz2 X-ray (GPUs 0,1)"
+[[ "$RUN_BOLTZ2_MD" == true ]] && echo "  - Boltz2 MD (GPUs 2,3)"
+[[ "$RUN_RF3" == true ]] && echo "  - RosettaFold3 (GPUs 4,5)"
+[[ "$RUN_PROTENIX" == true ]] && echo "  - Protenix (GPUs 6,7)"
+echo "=========================================="
+
+PIDS=()
+NAMES=()
+
+start_grid_search() {
+    local name="$1"
+    local gpu_devices="$2"
+    local log_file="$3"
+    shift 3
+
+    echo "[$(date)] Starting $name on GPUs $gpu_devices"
+    CUDA_VISIBLE_DEVICES="$gpu_devices" "$RUN_GRID_SEARCH_ACTL" "$@" 2>&1 | tee "$log_file" &
+    PIDS+=("$!")
+    NAMES+=("$name")
+    echo "[$(date)] $name job started (PID: ${PIDS[-1]})"
+}
+
+if [[ "$RUN_BOLTZ2_XRD" == true ]]; then
+    start_grid_search "Boltz2 X-ray" "0,1" "$RESULTS_DIR/boltz2_xrd_run.log" \
+        --model boltz2 --method "X-RAY DIFFRACTION" --proteins "$PROTEINS_CSV" \
+        --scalers pure_guidance --partial-diffusion-step 120 --ensemble-sizes "8" \
+        --gradient-weights "0.1 0.2 0.5" --gradient-normalization --augmentation \
+        --align-to-input --output-dir "$RESULTS_DIR"
+fi
+
+if [[ "$RUN_BOLTZ2_MD" == true ]]; then
+    start_grid_search "Boltz2 MD" "2,3" "$RESULTS_DIR/boltz2_md_run.log" \
+        --model boltz2 --method "MD" --proteins "$PROTEINS_CSV" \
+        --scalers pure_guidance --partial-diffusion-step 120 --ensemble-sizes "8" \
+        --gradient-weights "0.1 0.2 0.5" --gradient-normalization --augmentation \
+        --align-to-input --output-dir "$RESULTS_DIR"
+fi
+
+if [[ "$RUN_RF3" == true ]]; then
+    start_grid_search "RosettaFold3" "4,5" "$RESULTS_DIR/rf3_run.log" \
+        --model rf3 --proteins "$PROTEINS_CSV" --scalers pure_guidance \
+        --ensemble-sizes "8" --gradient-weights "0.01 0.02 0.05" \
+        --gradient-normalization --augmentation --align-to-input --output-dir "$RESULTS_DIR"
+fi
+
+if [[ "$RUN_PROTENIX" == true ]]; then
+    start_grid_search "Protenix" "6,7" "$RESULTS_DIR/protenix_run.log" \
+        --model protenix --proteins "$PROTEINS_CSV" --scalers pure_guidance \
+        --partial-diffusion-step 120 --ensemble-sizes "8" --gradient-weights "0.1 0.2 0.5" \
+        --gradient-normalization --augmentation --align-to-input --output-dir "$RESULTS_DIR"
+fi
+
+if [[ ${#PIDS[@]} -eq 0 ]]; then
+    echo "No models selected to run." >&2
+    exit 1
+fi
+
+echo "Waiting for ${#PIDS[@]} jobs: ${PIDS[*]}"
+failed=0
+for index in "${!PIDS[@]}"; do
+    if wait "${PIDS[$index]}"; then
+        echo "[$(date)] ${NAMES[$index]} completed successfully"
+    else
+        status=$?
+        echo "[$(date)] ${NAMES[$index]} failed with exit code $status" >&2
+        failed=1
+    fi
+done
+
+exit "$failed"

--- a/run_grid_search_actl.sh
+++ b/run_grid_search_actl.sh
@@ -8,13 +8,16 @@ show_help() {
 Run Sampleworks run_grid_search.py inside the already-running container.
 
 Usage:
-  run_grid_search_actl.sh [-e ENV] [run_grid_search.py args...]
+  run_grid_search_actl.sh [-e ENV] --proteins <csv> [run_grid_search.py args...]
   run_grid_search_actl.sh --model rf3 --proteins /data/input/proteins.csv --output-dir /data/results
 
 Options:
   -e, --env ENV   Pixi environment to use: boltz, protenix, or rf3.
-                  If omitted, inferred from --model/--models.
+                  If omitted, inferred from --model.
   -h, --help      Show this help message.
+
+Required:
+  --proteins CSV  Protein input CSV for run_grid_search.py.
 
 This script must be run from inside the Sampleworks image. It never starts Docker.
 EOF

--- a/run_grid_search_actl.sh
+++ b/run_grid_search_actl.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Run Sampleworks grid search natively inside the current ACTL/Kubernetes container.
+
+set -euo pipefail
+
+show_help() {
+    cat << 'EOF'
+Run Sampleworks run_grid_search.py inside the already-running container.
+
+Usage:
+  run_grid_search_actl.sh [-e ENV] [run_grid_search.py args...]
+  run_grid_search_actl.sh --model rf3 --proteins /data/input/proteins.csv --output-dir /data/results
+
+Options:
+  -e, --env ENV   Pixi environment to use: boltz, protenix, or rf3.
+                  If omitted, inferred from --model/--models.
+  -h, --help      Show this help message.
+
+This script must be run from inside the Sampleworks image. It never starts Docker.
+EOF
+}
+
+infer_env_from_model() {
+    case "$1" in
+        boltz1|boltz2) echo "boltz" ;;
+        protenix) echo "protenix" ;;
+        rf3) echo "rf3" ;;
+        *) echo "Error: unknown model '$1'. Expected boltz1, boltz2, protenix, or rf3." >&2; exit 1 ;;
+    esac
+}
+
+ENV_NAME=""
+ARGS=()
+MODEL="boltz2"
+PROTEINS_FILE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        -e|--env)
+            if [[ -z "${2:-}" || "${2:-}" == -* ]]; then
+                echo "Error: $1 requires an environment name: boltz, protenix, or rf3" >&2
+                exit 1
+            fi
+            ENV_NAME="$2"
+            shift 2
+            ;;
+        --model|--models)
+            if [[ -z "${2:-}" || "${2:-}" == -* ]]; then
+                echo "Error: $1 requires a model value" >&2
+                exit 1
+            fi
+            MODEL="$2"
+            ARGS+=("--model" "$2")
+            shift 2
+            ;;
+        --method|--methods)
+            if [[ -z "${2:-}" || "${2:-}" == -* ]]; then
+                echo "Error: $1 requires a method value" >&2
+                exit 1
+            fi
+            ARGS+=("--method" "$2")
+            shift 2
+            ;;
+        --proteins)
+            if [[ -z "${2:-}" || "${2:-}" == -* ]]; then
+                echo "Error: --proteins requires a CSV file path" >&2
+                exit 1
+            fi
+            PROTEINS_FILE="$2"
+            ARGS+=("$1" "$2")
+            shift 2
+            ;;
+        run_grid_search.py|/app/run_grid_search.py)
+            shift
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [[ ${#ARGS[@]} -eq 0 ]]; then
+    show_help >&2
+    exit 1
+fi
+
+if [[ -n "$PROTEINS_FILE" ]]; then
+    if [[ ! -f "$PROTEINS_FILE" ]]; then
+        echo "Error: proteins CSV not found: $PROTEINS_FILE" >&2
+        exit 1
+    fi
+else
+    echo "Error: pass --proteins <csv>" >&2
+    exit 1
+fi
+
+if [[ -z "$ENV_NAME" ]]; then
+    ENV_NAME="$(infer_env_from_model "$MODEL")"
+fi
+
+case "$ENV_NAME" in
+    boltz|protenix|rf3) ;;
+    *) echo "Error: invalid pixi environment '$ENV_NAME'. Expected boltz, protenix, or rf3." >&2; exit 1 ;;
+esac
+
+exec pixi run -e "$ENV_NAME" python /app/run_grid_search.py "${ARGS[@]}"

--- a/run_protenix_mini_tiny_actl.sh
+++ b/run_protenix_mini_tiny_actl.sh
@@ -19,8 +19,17 @@ fi
 
 DATA_DIR="${DATA_DIR:-/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps}"
 MSA_CACHE_DIR="${MSA_CACHE_DIR:-/data/sampleworks-exp/msa_cache}"
-TINY_RESULTS_DIR="${TINY_RESULTS_DIR:-${RESULTS_DIR:-/data/sampleworks-exp/occ_sweep/grid_search_results_protenix_tiny}}"
-MINI_RESULTS_DIR="${MINI_RESULTS_DIR:-${RESULTS_DIR:-/data/sampleworks-exp/occ_sweep/grid_search_results_protenix_mini}}"
+if [[ -n "${RESULTS_DIR:-}" ]]; then
+    TINY_RESULTS_DIR="${TINY_RESULTS_DIR:-$RESULTS_DIR/protenix_tiny}"
+    MINI_RESULTS_DIR="${MINI_RESULTS_DIR:-$RESULTS_DIR/protenix_mini}"
+    TINY_LOG_FILE="$RESULTS_DIR/protenix_tiny_run.log"
+    MINI_LOG_FILE="$RESULTS_DIR/protenix_mini_run.log"
+else
+    TINY_RESULTS_DIR="${TINY_RESULTS_DIR:-/data/sampleworks-exp/occ_sweep/grid_search_results_protenix_tiny}"
+    MINI_RESULTS_DIR="${MINI_RESULTS_DIR:-/data/sampleworks-exp/occ_sweep/grid_search_results_protenix_mini}"
+    TINY_LOG_FILE="$TINY_RESULTS_DIR/protenix_tiny_run.log"
+    MINI_LOG_FILE="$MINI_RESULTS_DIR/protenix_mini_run.log"
+fi
 PROTEINS_CSV="${PROTEINS_CSV:-$DATA_DIR/proteins.csv}"
 TINY_GPU_DEVICES="${TINY_GPU_DEVICES:-2,3}"
 MINI_GPU_DEVICES="${MINI_GPU_DEVICES:-6,7}"
@@ -39,8 +48,12 @@ if [[ ! -f "$PROTENIX_MINI_CHECKPOINT" ]]; then
     echo "Error: Protenix mini checkpoint not found: $PROTENIX_MINI_CHECKPOINT" >&2
     exit 1
 fi
+if [[ "$TINY_RESULTS_DIR" == "$MINI_RESULTS_DIR" ]]; then
+    echo "Error: TINY_RESULTS_DIR and MINI_RESULTS_DIR must be different for parallel runs." >&2
+    exit 1
+fi
 
-mkdir -p "$TINY_RESULTS_DIR" "$MINI_RESULTS_DIR" "$MSA_CACHE_DIR"
+mkdir -p "$TINY_RESULTS_DIR" "$MINI_RESULTS_DIR" "$(dirname "$TINY_LOG_FILE")" "$(dirname "$MINI_LOG_FILE")" "$MSA_CACHE_DIR"
 
 PIDS=()
 NAMES=()
@@ -53,24 +66,27 @@ start_protenix() {
     local log_file="$5"
 
     echo "[$(date)] Starting $name on GPUs $gpu_devices"
-    CUDA_VISIBLE_DEVICES="$gpu_devices" "$RUN_GRID_SEARCH_ACTL" \
-        --model protenix \
-        --proteins "$PROTEINS_CSV" \
-        --model-checkpoint "$checkpoint" \
-        --scalers pure_guidance \
-        --partial-diffusion-step 120 \
-        --ensemble-sizes "8" \
-        --gradient-weights "0.0 0.05 0.1 0.2 0.35 0.5" \
-        --gradient-normalization --augmentation --align-to-input \
-        --output-dir "$output_dir" \
-        2>&1 | tee "$log_file" &
+    (
+        set -o pipefail
+        CUDA_VISIBLE_DEVICES="$gpu_devices" "$RUN_GRID_SEARCH_ACTL" \
+            --model protenix \
+            --proteins "$PROTEINS_CSV" \
+            --model-checkpoint "$checkpoint" \
+            --scalers pure_guidance \
+            --partial-diffusion-step 120 \
+            --ensemble-sizes "8" \
+            --gradient-weights "0.0 0.05 0.1 0.2 0.35 0.5" \
+            --gradient-normalization --augmentation --align-to-input \
+            --output-dir "$output_dir" \
+            2>&1 | tee "$log_file"
+    ) &
     PIDS+=("$!")
     NAMES+=("$name")
     echo "[$(date)] $name job started (PID: ${PIDS[-1]})"
 }
 
-start_protenix "Protenix tiny" "$TINY_GPU_DEVICES" "$PROTENIX_TINY_CHECKPOINT" "$TINY_RESULTS_DIR" "$TINY_RESULTS_DIR/protenix_tiny_run.log"
-start_protenix "Protenix mini" "$MINI_GPU_DEVICES" "$PROTENIX_MINI_CHECKPOINT" "$MINI_RESULTS_DIR" "$MINI_RESULTS_DIR/protenix_mini_run.log"
+start_protenix "Protenix tiny" "$TINY_GPU_DEVICES" "$PROTENIX_TINY_CHECKPOINT" "$TINY_RESULTS_DIR" "$TINY_LOG_FILE"
+start_protenix "Protenix mini" "$MINI_GPU_DEVICES" "$PROTENIX_MINI_CHECKPOINT" "$MINI_RESULTS_DIR" "$MINI_LOG_FILE"
 
 failed=0
 for index in "${!PIDS[@]}"; do

--- a/run_protenix_mini_tiny_actl.sh
+++ b/run_protenix_mini_tiny_actl.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Run Protenix tiny and mini grid searches inside the current container.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_GRID_SEARCH_ACTL="${RUN_GRID_SEARCH_ACTL:-$SCRIPT_DIR/run_grid_search_actl.sh}"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    cat << 'EOF'
+Usage: run_protenix_mini_tiny_actl.sh
+
+Environment overrides:
+  DATA_DIR, MSA_CACHE_DIR, TINY_RESULTS_DIR, MINI_RESULTS_DIR, PROTEINS_CSV
+  TINY_GPU_DEVICES, MINI_GPU_DEVICES, PROTENIX_TINY_CHECKPOINT, PROTENIX_MINI_CHECKPOINT
+EOF
+    exit 0
+fi
+
+DATA_DIR="${DATA_DIR:-/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps}"
+MSA_CACHE_DIR="${MSA_CACHE_DIR:-/data/sampleworks-exp/msa_cache}"
+TINY_RESULTS_DIR="${TINY_RESULTS_DIR:-${RESULTS_DIR:-/data/sampleworks-exp/occ_sweep/grid_search_results_protenix_tiny}}"
+MINI_RESULTS_DIR="${MINI_RESULTS_DIR:-${RESULTS_DIR:-/data/sampleworks-exp/occ_sweep/grid_search_results_protenix_mini}}"
+PROTEINS_CSV="${PROTEINS_CSV:-$DATA_DIR/proteins.csv}"
+TINY_GPU_DEVICES="${TINY_GPU_DEVICES:-2,3}"
+MINI_GPU_DEVICES="${MINI_GPU_DEVICES:-6,7}"
+PROTENIX_TINY_CHECKPOINT="${PROTENIX_TINY_CHECKPOINT:-/extra_checkpoints/protenix_tiny_default_v0.5.0.pt}"
+PROTENIX_MINI_CHECKPOINT="${PROTENIX_MINI_CHECKPOINT:-/extra_checkpoints/protenix_mini_default_v0.5.0.pt}"
+
+if [[ ! -f "$PROTEINS_CSV" ]]; then
+    echo "Error: proteins CSV not found: $PROTEINS_CSV" >&2
+    exit 1
+fi
+if [[ ! -f "$PROTENIX_TINY_CHECKPOINT" ]]; then
+    echo "Error: Protenix tiny checkpoint not found: $PROTENIX_TINY_CHECKPOINT" >&2
+    exit 1
+fi
+if [[ ! -f "$PROTENIX_MINI_CHECKPOINT" ]]; then
+    echo "Error: Protenix mini checkpoint not found: $PROTENIX_MINI_CHECKPOINT" >&2
+    exit 1
+fi
+
+mkdir -p "$TINY_RESULTS_DIR" "$MINI_RESULTS_DIR" "$MSA_CACHE_DIR"
+
+PIDS=()
+NAMES=()
+
+start_protenix() {
+    local name="$1"
+    local gpu_devices="$2"
+    local checkpoint="$3"
+    local output_dir="$4"
+    local log_file="$5"
+
+    echo "[$(date)] Starting $name on GPUs $gpu_devices"
+    CUDA_VISIBLE_DEVICES="$gpu_devices" "$RUN_GRID_SEARCH_ACTL" \
+        --model protenix \
+        --proteins "$PROTEINS_CSV" \
+        --model-checkpoint "$checkpoint" \
+        --scalers pure_guidance \
+        --partial-diffusion-step 120 \
+        --ensemble-sizes "8" \
+        --gradient-weights "0.0 0.05 0.1 0.2 0.35 0.5" \
+        --gradient-normalization --augmentation --align-to-input \
+        --output-dir "$output_dir" \
+        2>&1 | tee "$log_file" &
+    PIDS+=("$!")
+    NAMES+=("$name")
+    echo "[$(date)] $name job started (PID: ${PIDS[-1]})"
+}
+
+start_protenix "Protenix tiny" "$TINY_GPU_DEVICES" "$PROTENIX_TINY_CHECKPOINT" "$TINY_RESULTS_DIR" "$TINY_RESULTS_DIR/protenix_tiny_run.log"
+start_protenix "Protenix mini" "$MINI_GPU_DEVICES" "$PROTENIX_MINI_CHECKPOINT" "$MINI_RESULTS_DIR" "$MINI_RESULTS_DIR/protenix_mini_run.log"
+
+failed=0
+for index in "${!PIDS[@]}"; do
+    if wait "${PIDS[$index]}"; then
+        echo "[$(date)] ${NAMES[$index]} completed successfully"
+    else
+        status=$?
+        echo "[$(date)] ${NAMES[$index]} failed with exit code $status" >&2
+        failed=1
+    fi
+done
+
+exit "$failed"

--- a/run_rf3_partial_actl.sh
+++ b/run_rf3_partial_actl.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Run RF3 partial-diffusion grid search inside the current container.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_GRID_SEARCH_ACTL="${RUN_GRID_SEARCH_ACTL:-$SCRIPT_DIR/run_grid_search_actl.sh}"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    cat << 'EOF'
+Usage: run_rf3_partial_actl.sh
+
+Environment overrides:
+  DATA_DIR       Input directory containing proteins.csv
+  RESULTS_DIR    Output directory
+  MSA_CACHE_DIR  MSA cache directory
+  PROTEINS_CSV   Explicit proteins CSV path
+  GPU_DEVICES    CUDA_VISIBLE_DEVICES value
+EOF
+    exit 0
+fi
+
+DATA_DIR="${DATA_DIR:-/mnt/diffuse-private/raw/sampleworks/initial_dataset_40}"
+RESULTS_DIR="${RESULTS_DIR:-${HOME}/sampleworks-exp/grid_search_results_rf3_partial}"
+MSA_CACHE_DIR="${MSA_CACHE_DIR:-${HOME}/sampleworks-exp/msa_cache}"
+PROTEINS_CSV="${PROTEINS_CSV:-$DATA_DIR/proteins.csv}"
+GPU_DEVICES="${GPU_DEVICES:-4,5}"
+
+if [[ ! -f "$PROTEINS_CSV" ]]; then
+    echo "Error: proteins CSV not found: $PROTEINS_CSV" >&2
+    exit 1
+fi
+
+mkdir -p "$RESULTS_DIR" "$MSA_CACHE_DIR"
+
+echo "[$(date)] Starting RF3 partial run on GPUs $GPU_DEVICES"
+CUDA_VISIBLE_DEVICES="$GPU_DEVICES" "$RUN_GRID_SEARCH_ACTL" \
+    --model rf3 \
+    --proteins "$PROTEINS_CSV" \
+    --scalers pure_guidance \
+    --partial-diffusion-step 120 \
+    --ensemble-sizes "8" \
+    --gradient-weights "0.01 0.02 0.05" \
+    --gradient-normalization --augmentation --align-to-input \
+    --output-dir "$RESULTS_DIR" \
+    --model-checkpoint "${RF3_CHECKPOINT:-/checkpoints/rf3_foundry_01_24_latest.ckpt}" \
+    2>&1 | tee "$RESULTS_DIR/rf3_partial_run.log"
+
+echo "[$(date)] RF3 job completed."

--- a/run_rf3_partial_actl.sh
+++ b/run_rf3_partial_actl.sh
@@ -16,6 +16,7 @@ Environment overrides:
   MSA_CACHE_DIR  MSA cache directory
   PROTEINS_CSV   Explicit proteins CSV path
   GPU_DEVICES    CUDA_VISIBLE_DEVICES value
+  RF3_CHECKPOINT  RF3 checkpoint path
 EOF
     exit 0
 fi

--- a/run_rf3_partial_fixed_actl.sh
+++ b/run_rf3_partial_fixed_actl.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Run RF3 partial occ-sweep grid search inside the current container.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_GRID_SEARCH_ACTL="${RUN_GRID_SEARCH_ACTL:-$SCRIPT_DIR/run_grid_search_actl.sh}"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    cat << 'EOF'
+Usage: run_rf3_partial_fixed_actl.sh
+
+Environment overrides: DATA_DIR, RESULTS_DIR, MSA_CACHE_DIR, PROTEINS_CSV, GPU_DEVICES, RF3_CHECKPOINT
+EOF
+    exit 0
+fi
+
+DATA_DIR="${DATA_DIR:-/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps}"
+RESULTS_DIR="${RESULTS_DIR:-${HOME}/sampleworks-exp/occ_sweep/grid_search_results}"
+MSA_CACHE_DIR="${MSA_CACHE_DIR:-${HOME}/sampleworks-exp/msa_cache}"
+PROTEINS_CSV="${PROTEINS_CSV:-$DATA_DIR/proteins.csv}"
+GPU_DEVICES="${GPU_DEVICES:-4}"
+
+if [[ ! -f "$PROTEINS_CSV" ]]; then
+    echo "Error: proteins CSV not found: $PROTEINS_CSV" >&2
+    exit 1
+fi
+
+mkdir -p "$RESULTS_DIR" "$MSA_CACHE_DIR"
+
+echo "[$(date)] Starting RF3 occ-sweep partial run on GPUs $GPU_DEVICES"
+CUDA_VISIBLE_DEVICES="$GPU_DEVICES" "$RUN_GRID_SEARCH_ACTL" \
+    --model rf3 \
+    --proteins "$PROTEINS_CSV" \
+    --scalers pure_guidance \
+    --partial-diffusion-step 120 \
+    --ensemble-sizes "8" \
+    --gradient-weights "0.0 0.005 0.01 0.02 0.035 0.05 0.1" \
+    --gradient-normalization --augmentation --align-to-input \
+    --output-dir "$RESULTS_DIR" \
+    --model-checkpoint "${RF3_CHECKPOINT:-/checkpoints/rf3_foundry_01_24_latest.ckpt}" \
+    2>&1 | tee "$RESULTS_DIR/rf3_partial_run_occ_sweep.log"
+
+echo "[$(date)] RF3 job completed."

--- a/run_rf3_protenix_mdc_actl.sh
+++ b/run_rf3_protenix_mdc_actl.sh
@@ -29,33 +29,42 @@ fi
 
 mkdir -p "$RESULTS_DIR" "$MSA_CACHE_DIR"
 
+RF3_RESULTS_DIR="$RESULTS_DIR/rf3"
+PROTENIX_RESULTS_DIR="$RESULTS_DIR/protenix"
+
 PIDS=()
 NAMES=()
 
 echo "[$(date)] Starting RF3 on GPUs $RF3_GPU_DEVICES"
-CUDA_VISIBLE_DEVICES="$RF3_GPU_DEVICES" "$RUN_GRID_SEARCH_ACTL" \
-    --model rf3 \
-    --proteins "$PROTEINS_CSV" \
-    --scalers pure_guidance \
-    --ensemble-sizes "8" \
-    --gradient-weights "0.0 0.01 0.02 0.05 0.1" \
-    --gradient-normalization --augmentation --align-to-input \
-    --output-dir "$RESULTS_DIR" \
-    2>&1 | tee "$RESULTS_DIR/rf3_run.log" &
+(
+    set -o pipefail
+    CUDA_VISIBLE_DEVICES="$RF3_GPU_DEVICES" "$RUN_GRID_SEARCH_ACTL" \
+        --model rf3 \
+        --proteins "$PROTEINS_CSV" \
+        --scalers pure_guidance \
+        --ensemble-sizes "8" \
+        --gradient-weights "0.0 0.01 0.02 0.05 0.1" \
+        --gradient-normalization --augmentation --align-to-input \
+        --output-dir "$RF3_RESULTS_DIR" \
+        2>&1 | tee "$RESULTS_DIR/rf3_run.log"
+) &
 PIDS+=("$!")
 NAMES+=("RF3")
 
 echo "[$(date)] Starting Protenix on GPUs $PROTENIX_GPU_DEVICES"
-CUDA_VISIBLE_DEVICES="$PROTENIX_GPU_DEVICES" "$RUN_GRID_SEARCH_ACTL" \
-    --model protenix \
-    --proteins "$PROTEINS_CSV" \
-    --scalers pure_guidance \
-    --partial-diffusion-step 120 \
-    --ensemble-sizes "8" \
-    --gradient-weights "0.0 0.1 0.2 0.5" \
-    --gradient-normalization --augmentation --align-to-input \
-    --output-dir "$RESULTS_DIR" \
-    2>&1 | tee "$RESULTS_DIR/protenix_run.log" &
+(
+    set -o pipefail
+    CUDA_VISIBLE_DEVICES="$PROTENIX_GPU_DEVICES" "$RUN_GRID_SEARCH_ACTL" \
+        --model protenix \
+        --proteins "$PROTEINS_CSV" \
+        --scalers pure_guidance \
+        --partial-diffusion-step 120 \
+        --ensemble-sizes "8" \
+        --gradient-weights "0.0 0.1 0.2 0.5" \
+        --gradient-normalization --augmentation --align-to-input \
+        --output-dir "$PROTENIX_RESULTS_DIR" \
+        2>&1 | tee "$RESULTS_DIR/protenix_run.log"
+) &
 PIDS+=("$!")
 NAMES+=("Protenix")
 

--- a/run_rf3_protenix_mdc_actl.sh
+++ b/run_rf3_protenix_mdc_actl.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Run RF3 and Protenix grid searches inside the current container.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_GRID_SEARCH_ACTL="${RUN_GRID_SEARCH_ACTL:-$SCRIPT_DIR/run_grid_search_actl.sh}"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    cat << 'EOF'
+Usage: run_rf3_protenix_mdc_actl.sh
+
+Environment overrides: DATA_DIR, RESULTS_DIR, MSA_CACHE_DIR, PROTEINS_CSV, RF3_GPU_DEVICES, PROTENIX_GPU_DEVICES
+EOF
+    exit 0
+fi
+
+DATA_DIR="${DATA_DIR:-/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps}"
+RESULTS_DIR="${RESULTS_DIR:-${HOME}/sampleworks-exp/occ_sweep/grid_search_results}"
+MSA_CACHE_DIR="${MSA_CACHE_DIR:-${HOME}/sampleworks-exp/msa_cache}"
+PROTEINS_CSV="${PROTEINS_CSV:-$DATA_DIR/proteins.csv}"
+RF3_GPU_DEVICES="${RF3_GPU_DEVICES:-0,1,2,3}"
+PROTENIX_GPU_DEVICES="${PROTENIX_GPU_DEVICES:-4,5,6,7}"
+
+if [[ ! -f "$PROTEINS_CSV" ]]; then
+    echo "Error: proteins CSV not found: $PROTEINS_CSV" >&2
+    exit 1
+fi
+
+mkdir -p "$RESULTS_DIR" "$MSA_CACHE_DIR"
+
+PIDS=()
+NAMES=()
+
+echo "[$(date)] Starting RF3 on GPUs $RF3_GPU_DEVICES"
+CUDA_VISIBLE_DEVICES="$RF3_GPU_DEVICES" "$RUN_GRID_SEARCH_ACTL" \
+    --model rf3 \
+    --proteins "$PROTEINS_CSV" \
+    --scalers pure_guidance \
+    --ensemble-sizes "8" \
+    --gradient-weights "0.0 0.01 0.02 0.05 0.1" \
+    --gradient-normalization --augmentation --align-to-input \
+    --output-dir "$RESULTS_DIR" \
+    2>&1 | tee "$RESULTS_DIR/rf3_run.log" &
+PIDS+=("$!")
+NAMES+=("RF3")
+
+echo "[$(date)] Starting Protenix on GPUs $PROTENIX_GPU_DEVICES"
+CUDA_VISIBLE_DEVICES="$PROTENIX_GPU_DEVICES" "$RUN_GRID_SEARCH_ACTL" \
+    --model protenix \
+    --proteins "$PROTEINS_CSV" \
+    --scalers pure_guidance \
+    --partial-diffusion-step 120 \
+    --ensemble-sizes "8" \
+    --gradient-weights "0.0 0.1 0.2 0.5" \
+    --gradient-normalization --augmentation --align-to-input \
+    --output-dir "$RESULTS_DIR" \
+    2>&1 | tee "$RESULTS_DIR/protenix_run.log" &
+PIDS+=("$!")
+NAMES+=("Protenix")
+
+failed=0
+for index in "${!PIDS[@]}"; do
+    if wait "${PIDS[$index]}"; then
+        echo "[$(date)] ${NAMES[$index]} completed successfully"
+    else
+        status=$?
+        echo "[$(date)] ${NAMES[$index]} failed with exit code $status" >&2
+        failed=1
+    fi
+done
+
+exit "$failed"


### PR DESCRIPTION
## Summary
- Add ACTL/Kubernetes-native Sampleworks shell wrappers that run inside the already-started container instead of launching nested Docker.
- Add a generic `run_grid_search_actl.sh` wrapper plus ACTL copies for all-model, RF3, Protenix, and MDC wrapper flows.
- Update the image entrypoint/Dockerfile to bundle and directly execute `*_actl.sh` wrappers.

## Validation
- `bash -n docker-entrypoint.sh`
- `for script in *_actl.sh; do bash -n "$script"; done`
- Searched ACTL wrappers for nested Docker launch patterns; none found.

## Notes
- Targets `main` directly.
- Original Docker-launching wrappers are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added container-native wrapper scripts to run model grid searches inside Kubernetes/ACTL containers (no Docker-in-Docker).
  * Orchestration for running multiple model grid searches in parallel with configurable GPU pinning and per-job logs.
  * New specialized runners for RF3 partial-diffusion sweeps and Protenix variant runs, with env-var configuration and checkpoint support.
  * Improved entrypoint help and handling to recognize and directly execute bundled ACTL wrapper commands.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diff-use/sampleworks/pull/233)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->