### PR TITLE
feat(runs): add sampleworks-runs preset orchestrator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,7 @@ src/sampleworks/
 ├── metrics/               # Quality metrics (LDDT, sidechain)
 ├── eval/                  # Evaluation utilities
 ├── data/                  # Reference data (protein configs)
+├── runs/                  # `sampleworks-runs` CLI + TOML preset orchestrator
 └── utils/                 # Shared utilities
 ```
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,32 @@ Output layout: `grid_search_results/<protein>/<model>[_<method>]/<scaler>/ens<N>
 Instructions for running evaluation and metrics scripts are coming soon.
 
 
+## Preset experiments (`sampleworks-runs`)
+
+For canonical multi-model/multi-GPU sweeps, the `sampleworks-runs` CLI orchestrates parallel `run_grid_search.py` jobs from a single TOML preset. Each preset declares its jobs (model, pixi env, GPU assignment, args); the runner launches them in parallel, tees per-job logs, and aggregates exit codes.
+
+```bash
+pixi run -e rf3 sampleworks-runs --list                          # bundled presets
+pixi run -e rf3 sampleworks-runs rf3_partial                     # run a preset
+pixi run -e rf3 sampleworks-runs rf3_partial --show              # inspect resolved values
+pixi run -e rf3 sampleworks-runs rf3_partial --dry-run           # print pixi run commands, don't execute
+pixi run -e rf3 sampleworks-runs all_models --only rf3,protenix  # subset jobs
+
+# Override any value without editing the TOML:
+pixi run -e rf3 sampleworks-runs rf3_partial \
+    --set jobs.rf3.gpus=7 \
+    --set jobs.rf3.args.gradient-weights="0.0 0.01 0.02"
+```
+
+Bundled presets live in `src/sampleworks/runs/presets/*.toml`. Add a new preset by dropping a `.toml` file alongside them or pointing at any path:
+
+```bash
+sampleworks-runs ./my_experiment.toml
+```
+
+Env-var defaults (`DATA_DIR`, `RESULTS_DIR`, `MSA_CACHE_DIR`, `PROTEINS_CSV`) declared per preset are filled from the process environment when set, otherwise from the preset's `[defaults]` block.
+
+
 ## Docker
 
 TODO: Docker container documentation

--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ Instructions for running evaluation and metrics scripts are coming soon.
 
 For canonical multi-model/multi-GPU sweeps, the `sampleworks-runs` CLI orchestrates parallel `run_grid_search.py` jobs from a single TOML preset. Each preset declares its jobs (model, pixi env, GPU assignment, args); the runner launches them in parallel, tees per-job logs, and aggregates exit codes.
 
+**Pod-side prerequisite.** Bundled presets reference the canonical `/data/inputs`, `/data/results`, and `/root/.sampleworks` paths set up by the ACTL pod-init script. On a fresh sampleworks pod, run once per session:
+
+```bash
+bash /mnt/diffuse-shared/raw/sampleworks/actl_setup_sampleworks_paths.sh
+```
+
+That creates symlinks pointing the canonical paths at the shared mount (and namespaces `/data/results` by hostname or `$SAMPLEWORKS_ACTL_RUN_NAME`). Overrides via env var (`DATA_DIR=...`) or CLI (`--set defaults.DATA_DIR=...`) work without the symlinks.
+
 ```bash
 pixi run -e rf3 sampleworks-runs --list                          # bundled presets
 pixi run -e rf3 sampleworks-runs rf3_partial                     # run a preset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ version = "0.6.2"
 
 [project.scripts]
 sampleworks-guidance = "sampleworks.cli.guidance:main"
+sampleworks-runs = "sampleworks.runs.cli:main"
+
+[tool.hatch.build.targets.wheel.force-include]
+"src/sampleworks/runs/presets" = "sampleworks/runs/presets"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/src/sampleworks/runs/__init__.py
+++ b/src/sampleworks/runs/__init__.py
@@ -1,0 +1,5 @@
+"""Preset-driven orchestrator for parallel run_grid_search.py invocations.
+
+Replaces the previous ACTL-native bash wrapper scripts with TOML presets +
+a thin Python runner. See ``sampleworks-runs --help``.
+"""

--- a/src/sampleworks/runs/cli.py
+++ b/src/sampleworks/runs/cli.py
@@ -1,0 +1,122 @@
+"""Command-line entry point for ``sampleworks-runs``."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from . import loader, runner
+from .schema import Preset
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.list:
+        for name in loader.list_bundled_presets():
+            print(name)
+        return 0
+
+    if args.preset is None:
+        parser.error("PRESET is required (or pass --list)")
+
+    preset = loader.load_preset(args.preset, overrides=args.set)
+    if args.only:
+        preset = _filter_only(preset, args.only)
+
+    if args.show:
+        _print_show(preset)
+        return 0
+
+    results_dir = Path(args.results_dir or _default_results_dir(preset))
+    return runner.run(preset, results_dir=results_dir, dry_run=args.dry_run)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sampleworks-runs",
+        description=(
+            "Run a preset of parallel run_grid_search.py jobs. "
+            "Presets are TOML files bundled under sampleworks.runs.presets, "
+            "or pass a path to a .toml file directly."
+        ),
+    )
+    parser.add_argument("preset", nargs="?", help="Bundled preset name or path to a .toml file")
+    parser.add_argument("--list", action="store_true", help="List bundled presets and exit")
+    parser.add_argument("--show", action="store_true", help="Print the resolved preset and exit")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the pixi run commands instead of executing them",
+    )
+    parser.add_argument(
+        "--only",
+        default="",
+        help="Comma-separated job names to run (subset). Default: all jobs.",
+    )
+    parser.add_argument(
+        "--set",
+        action="append",
+        default=[],
+        metavar="DOTTED_KEY=VALUE",
+        help=(
+            "Override a value in the loaded preset. Examples: "
+            "--set defaults.DATA_DIR=/data/foo, "
+            "--set jobs.rf3.args.gradient-weights='0.0 0.01', "
+            "--set jobs.0.gpus=5"
+        ),
+    )
+    parser.add_argument(
+        "--results-dir",
+        default=None,
+        help="Override RESULTS_DIR for this run (also controls per-job log location).",
+    )
+    return parser
+
+
+def _filter_only(preset: Preset, only: str) -> Preset:
+    names = [n.strip() for n in only.split(",") if n.strip()]
+    keep = [j for j in preset.jobs if j.name in names]
+    missing = set(names) - {j.name for j in keep}
+    if missing:
+        raise SystemExit(f"--only references unknown jobs: {sorted(missing)}")
+    return Preset(
+        name=preset.name,
+        description=preset.description,
+        defaults=preset.defaults,
+        jobs=keep,
+    )
+
+
+def _print_show(preset: Preset) -> None:
+    print(f"name: {preset.name}")
+    if preset.description:
+        print(f"description: {preset.description}")
+    if preset.defaults:
+        print("defaults:")
+        for k, v in preset.defaults.items():
+            print(f"  {k} = {v}")
+    print("jobs:")
+    for j in preset.jobs:
+        print(f"  - name: {j.name}")
+        print(f"    env: {j.env}")
+        print(f"    gpus: {j.gpus}")
+        print(f"    output_subdir: {j.output_subdir}")
+        print("    args:")
+        for k, v in j.args.items():
+            print(f"      {k} = {v!r}")
+
+
+def _default_results_dir(preset: Preset) -> str:
+    return (
+        preset.defaults.get("RESULTS_DIR")
+        or os.environ.get("RESULTS_DIR")
+        or "./grid_search_results"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/sampleworks/runs/cli.py
+++ b/src/sampleworks/runs/cli.py
@@ -87,6 +87,7 @@ def _filter_only(preset: Preset, only: str) -> Preset:
         name=preset.name,
         description=preset.description,
         defaults=preset.defaults,
+        shared_args=preset.shared_args,
         jobs=keep,
     )
 

--- a/src/sampleworks/runs/cli.py
+++ b/src/sampleworks/runs/cli.py
@@ -12,6 +12,20 @@ from .schema import Preset
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``sampleworks-runs`` console script.
+
+    Parameters
+    ----------
+    argv : list of str or None, optional
+        Command-line arguments excluding the program name. When ``None``
+        (the default), :mod:`argparse` reads from :data:`sys.argv`.
+
+    Returns
+    -------
+    int
+        Exit code suitable for ``sys.exit``: ``0`` on success, non-zero on
+        job failure or fatal CLI error.
+    """
     parser = _build_parser()
     args = parser.parse_args(argv)
 
@@ -36,6 +50,13 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _build_parser() -> argparse.ArgumentParser:
+    """Construct the :mod:`argparse` parser for ``sampleworks-runs``.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        Parser covering preset selection, overrides, and execution flags.
+    """
     parser = argparse.ArgumentParser(
         prog="sampleworks-runs",
         description=(
@@ -78,6 +99,26 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _filter_only(preset: Preset, only: str) -> Preset:
+    """Return a new :class:`Preset` containing only the named jobs.
+
+    Parameters
+    ----------
+    preset : Preset
+        Source preset.
+    only : str
+        Comma-separated list of job names to keep.
+
+    Returns
+    -------
+    Preset
+        New preset with the same ``description``, ``defaults``, and
+        ``shared_args`` and only the filtered jobs.
+
+    Raises
+    ------
+    SystemExit
+        If any name in ``only`` does not match a job in ``preset``.
+    """
     names = [n.strip() for n in only.split(",") if n.strip()]
     keep = [j for j in preset.jobs if j.name in names]
     missing = set(names) - {j.name for j in keep}
@@ -93,6 +134,13 @@ def _filter_only(preset: Preset, only: str) -> Preset:
 
 
 def _print_show(preset: Preset) -> None:
+    """Print a human-readable rendering of a resolved preset to stdout.
+
+    Parameters
+    ----------
+    preset : Preset
+        Resolved preset to display (used by ``--show``).
+    """
     print(f"name: {preset.name}")
     if preset.description:
         print(f"description: {preset.description}")
@@ -112,6 +160,23 @@ def _print_show(preset: Preset) -> None:
 
 
 def _default_results_dir(preset: Preset) -> str:
+    """Pick a sensible default ``--results-dir`` when none is given.
+
+    Order of preference:
+      1. The preset's ``[defaults]`` ``RESULTS_DIR``.
+      2. The ``RESULTS_DIR`` environment variable.
+      3. ``./grid_search_results``.
+
+    Parameters
+    ----------
+    preset : Preset
+        Resolved preset (its ``defaults`` have already been merged with env).
+
+    Returns
+    -------
+    str
+        Path to use as the run's root output directory.
+    """
     return (
         preset.defaults.get("RESULTS_DIR")
         or os.environ.get("RESULTS_DIR")

--- a/src/sampleworks/runs/loader.py
+++ b/src/sampleworks/runs/loader.py
@@ -64,9 +64,17 @@ def _apply_overrides(raw: dict[str, Any], overrides: list[str]) -> dict[str, Any
     return raw
 
 
+_TOP_LEVEL_KEYS = frozenset({"description", "defaults", "shared_args", "jobs"})
+
+
 def _set_dotted(obj: dict[str, Any], dotted: str, value: Any) -> None:
     """Set ``obj`` at ``a.b.c`` to ``value``. Job name lookup is allowed under ``jobs``."""
     parts = dotted.split(".")
+    if parts[0] not in _TOP_LEVEL_KEYS:
+        raise KeyError(
+            f"--set: unknown top-level key {parts[0]!r} in {dotted!r}. "
+            f"Valid top-level keys: {sorted(_TOP_LEVEL_KEYS)}"
+        )
     cursor: Any = obj
     for i, part in enumerate(parts[:-1]):
         cursor = _index(cursor, part, where=".".join(parts[: i + 1]))

--- a/src/sampleworks/runs/loader.py
+++ b/src/sampleworks/runs/loader.py
@@ -21,16 +21,50 @@ from .schema import Job, Preset
 
 _BUNDLED_PRESETS_PACKAGE = "sampleworks.runs.presets"
 _VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+_TOP_LEVEL_KEYS = frozenset({"description", "defaults", "shared_args", "jobs"})
 
 
 def list_bundled_presets() -> list[str]:
-    """Return the names (sans ``.toml``) of bundled presets, sorted."""
+    """List the names of all TOML presets shipped with the package.
+
+    Returns
+    -------
+    list of str
+        Preset names (filename stems, no ``.toml`` extension), sorted
+        alphabetically.
+    """
     files = resources.files(_BUNDLED_PRESETS_PACKAGE)
     return sorted(p.name.removesuffix(".toml") for p in files.iterdir() if p.name.endswith(".toml"))
 
 
 def load_preset(name_or_path: str, *, overrides: Iterable[str] = ()) -> Preset:
-    """Load a preset by bundled name or filesystem path, applying ``--set`` overrides."""
+    """Load a preset by bundled name or filesystem path.
+
+    Parameters
+    ----------
+    name_or_path : str
+        Either the name of a bundled preset (as returned by
+        :func:`list_bundled_presets`) or a path ending in ``.toml``.
+    overrides : Iterable of str, optional
+        ``KEY=VALUE`` strings as accepted by ``--set``. Applied before
+        variable interpolation.
+
+    Returns
+    -------
+    Preset
+        Fully resolved preset ready for :func:`runner.run`.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``name_or_path`` matches no bundled preset and no file on disk.
+    KeyError
+        If an override path begins with an unknown top-level key, or if a
+        ``${VAR}`` reference cannot be resolved against the environment or
+        the ``[defaults]`` block.
+    ValueError
+        If an override is malformed (missing ``=``).
+    """
     raw = _read_toml(name_or_path)
     overrides_list = list(overrides)
     raw = _apply_overrides(raw, overrides_list)
@@ -39,6 +73,23 @@ def load_preset(name_or_path: str, *, overrides: Iterable[str] = ()) -> Preset:
 
 
 def _read_toml(name_or_path: str) -> dict[str, Any]:
+    """Read raw TOML from a filesystem path or a bundled package resource.
+
+    Parameters
+    ----------
+    name_or_path : str
+        Bundled preset name or filesystem path ending in ``.toml``.
+
+    Returns
+    -------
+    dict of str to Any
+        Parsed TOML, before override application or interpolation.
+
+    Raises
+    ------
+    FileNotFoundError
+        If neither location yields a TOML file.
+    """
     path = Path(name_or_path)
     if path.suffix == ".toml" and path.exists():
         return tomllib.loads(path.read_text())
@@ -52,10 +103,44 @@ def _read_toml(name_or_path: str) -> dict[str, Any]:
 
 
 def _preset_name(name_or_path: str) -> str:
+    """Return the canonical preset name for a bundled name or path argument.
+
+    Parameters
+    ----------
+    name_or_path : str
+        Either a bundled name or a path ending in ``.toml``.
+
+    Returns
+    -------
+    str
+        Filename stem if ``name_or_path`` looks like a path; otherwise the
+        argument unchanged.
+    """
     return Path(name_or_path).stem if name_or_path.endswith(".toml") else name_or_path
 
 
 def _apply_overrides(raw: dict[str, Any], overrides: list[str]) -> dict[str, Any]:
+    """Apply each ``KEY=VALUE`` override to the raw preset dict in place.
+
+    Parameters
+    ----------
+    raw : dict of str to Any
+        Parsed TOML to mutate.
+    overrides : list of str
+        Each entry must contain exactly one ``=``.
+
+    Returns
+    -------
+    dict of str to Any
+        The same ``raw`` dict (mutated).
+
+    Raises
+    ------
+    ValueError
+        If an override is missing the ``=`` separator.
+    KeyError
+        If an override's top-level key is unknown.
+    """
     for spec in overrides:
         if "=" not in spec:
             raise ValueError(f"--set expects KEY=VALUE, got {spec!r}")
@@ -64,11 +149,29 @@ def _apply_overrides(raw: dict[str, Any], overrides: list[str]) -> dict[str, Any
     return raw
 
 
-_TOP_LEVEL_KEYS = frozenset({"description", "defaults", "shared_args", "jobs"})
-
-
 def _set_dotted(obj: dict[str, Any], dotted: str, value: Any) -> None:
-    """Set ``obj`` at ``a.b.c`` to ``value``. Job name lookup is allowed under ``jobs``."""
+    """Set a nested value in ``obj`` addressed by a dotted path.
+
+    Job-list elements can be addressed by job name or by integer index.
+
+    Parameters
+    ----------
+    obj : dict of str to Any
+        Root dict to mutate.
+    dotted : str
+        Dotted path, e.g. ``"jobs.rf3.args.gradient-weights"`` or
+        ``"defaults.DATA_DIR"``.
+    value : Any
+        Coerced value to write at the leaf.
+
+    Raises
+    ------
+    KeyError
+        If the first segment is not one of :data:`_TOP_LEVEL_KEYS`, or if a
+        list segment references a missing job name or index.
+    TypeError
+        If the path attempts to descend through a non-container value.
+    """
     parts = dotted.split(".")
     if parts[0] not in _TOP_LEVEL_KEYS:
         raise KeyError(
@@ -87,6 +190,27 @@ def _set_dotted(obj: dict[str, Any], dotted: str, value: Any) -> None:
 
 
 def _index(cursor: Any, part: str, *, where: str) -> Any:
+    """Descend one level into a dict or list, auto-creating empty intermediates.
+
+    Parameters
+    ----------
+    cursor : Any
+        Current node in the traversal.
+    part : str
+        Next segment of the dotted path.
+    where : str
+        Path so far, used in error messages.
+
+    Returns
+    -------
+    Any
+        The child node.
+
+    Raises
+    ------
+    TypeError
+        If ``cursor`` is neither a dict nor a list.
+    """
     if isinstance(cursor, list):
         return cursor[_find_in_list(cursor, part, where=where)]
     if isinstance(cursor, dict):
@@ -97,6 +221,28 @@ def _index(cursor: Any, part: str, *, where: str) -> Any:
 
 
 def _find_in_list(items: list[Any], key: str, *, where: str) -> int:
+    """Locate a list element by integer index or by ``name`` field.
+
+    Parameters
+    ----------
+    items : list of Any
+        List to search.
+    key : str
+        Numeric string (positive or negative index) or a name to match against
+        each element's ``"name"`` key.
+    where : str
+        Path so far, used in error messages.
+
+    Returns
+    -------
+    int
+        Index of the matching element.
+
+    Raises
+    ------
+    KeyError
+        If no element with the given name exists.
+    """
     if key.isdigit() or (key.startswith("-") and key[1:].isdigit()):
         return int(key)
     for i, item in enumerate(items):
@@ -106,6 +252,19 @@ def _find_in_list(items: list[Any], key: str, *, where: str) -> int:
 
 
 def _coerce(value: str) -> Any:
+    """Convert a string CLI override value to bool, int, float, or leave as str.
+
+    Parameters
+    ----------
+    value : str
+        Right-hand side of ``KEY=VALUE``.
+
+    Returns
+    -------
+    Any
+        ``True``/``False`` for ``"true"``/``"false"`` (case-insensitive);
+        ``int`` or ``float`` if parseable; otherwise the original string.
+    """
     if value.lower() in ("true", "false"):
         return value.lower() == "true"
     try:
@@ -120,10 +279,27 @@ def _coerce(value: str) -> Any:
 
 
 def _resolve_variables(raw: dict[str, Any]) -> dict[str, Any]:
-    """Expand ``${VAR}`` in every string. Env wins; defaults block fills gaps.
+    """Expand ``${VAR}`` references throughout the raw preset.
 
-    Defaults are resolved in TOML order, so later defaults can reference earlier ones
-    (e.g. ``PROTEINS_CSV = "${DATA_DIR}/proteins.csv"``).
+    Defaults are resolved in TOML order, so later defaults can reference
+    earlier ones (e.g. ``PROTEINS_CSV = "${DATA_DIR}/proteins.csv"``). Process
+    environment variables take precedence over the ``[defaults]`` block.
+
+    Parameters
+    ----------
+    raw : dict of str to Any
+        Parsed TOML, after override application.
+
+    Returns
+    -------
+    dict of str to Any
+        New dict with all string values fully expanded and ``defaults``
+        replaced with the resolved values.
+
+    Raises
+    ------
+    KeyError
+        If any ``${VAR}`` cannot be resolved.
     """
     defaults: dict[str, str] = dict(raw.get("defaults", {}))
     accumulated: dict[str, str] = dict(os.environ)
@@ -140,6 +316,20 @@ def _resolve_variables(raw: dict[str, Any]) -> dict[str, Any]:
 
 
 def _walk(obj: Any, env: dict[str, str]) -> Any:
+    """Recursively expand ``${VAR}`` in every string within ``obj``.
+
+    Parameters
+    ----------
+    obj : Any
+        Arbitrary nested dict/list/scalar.
+    env : dict of str to str
+        Resolved variable map.
+
+    Returns
+    -------
+    Any
+        Structurally identical copy with strings expanded.
+    """
     if isinstance(obj, dict):
         return {k: _walk(v, env) for k, v in obj.items()}
     if isinstance(obj, list):
@@ -150,6 +340,26 @@ def _walk(obj: Any, env: dict[str, str]) -> Any:
 
 
 def _expand(text: str, env: dict[str, str]) -> str:
+    """Substitute ``${VAR}`` references in ``text`` until a fixed point.
+
+    Parameters
+    ----------
+    text : str
+        String potentially containing ``${VAR}`` references.
+    env : dict of str to str
+        Variable map.
+
+    Returns
+    -------
+    str
+        Fully expanded string.
+
+    Raises
+    ------
+    KeyError
+        If a referenced variable is not in ``env``.
+    """
+
     def repl(match: re.Match[str]) -> str:
         var = match.group(1)
         if var not in env:
@@ -165,6 +375,26 @@ def _expand(text: str, env: dict[str, str]) -> str:
 
 
 def _build_preset(*, name: str, raw: dict[str, Any]) -> Preset:
+    """Construct a :class:`Preset` from a resolved raw dict.
+
+    Parameters
+    ----------
+    name : str
+        Preset name (assigned to :attr:`Preset.name`).
+    raw : dict of str to Any
+        Resolved TOML.
+
+    Returns
+    -------
+    Preset
+        Validated preset.
+
+    Raises
+    ------
+    ValueError
+        If ``raw['jobs']`` is not a list, or if any :class:`Job` /
+        :class:`Preset` invariant fails (see their docstrings).
+    """
     raw_jobs = raw.get("jobs", [])
     if not isinstance(raw_jobs, list):
         raise ValueError(f"Preset {name!r}: 'jobs' must be a list")

--- a/src/sampleworks/runs/loader.py
+++ b/src/sampleworks/runs/loader.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from .schema import Job, Preset
 
+
 _BUNDLED_PRESETS_PACKAGE = "sampleworks.runs.presets"
 _VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 

--- a/src/sampleworks/runs/loader.py
+++ b/src/sampleworks/runs/loader.py
@@ -1,0 +1,178 @@
+"""Load presets from TOML and apply runtime overrides.
+
+Resolution order for every string value (defaults block and ``args``):
+  1. ``${VAR}`` references are resolved against the process environment,
+     with the preset's ``[defaults]`` block filling in any unset keys.
+  2. ``--set <dotted-path>=<value>`` CLI overrides are applied last.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tomllib
+from collections.abc import Iterable
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+from .schema import Job, Preset
+
+_BUNDLED_PRESETS_PACKAGE = "sampleworks.runs.presets"
+_VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def list_bundled_presets() -> list[str]:
+    """Return the names (sans ``.toml``) of bundled presets, sorted."""
+    files = resources.files(_BUNDLED_PRESETS_PACKAGE)
+    return sorted(p.name.removesuffix(".toml") for p in files.iterdir() if p.name.endswith(".toml"))
+
+
+def load_preset(name_or_path: str, *, overrides: Iterable[str] = ()) -> Preset:
+    """Load a preset by bundled name or filesystem path, applying ``--set`` overrides."""
+    raw = _read_toml(name_or_path)
+    overrides_list = list(overrides)
+    raw = _apply_overrides(raw, overrides_list)
+    raw = _resolve_variables(raw)
+    return _build_preset(name=_preset_name(name_or_path), raw=raw)
+
+
+def _read_toml(name_or_path: str) -> dict[str, Any]:
+    path = Path(name_or_path)
+    if path.suffix == ".toml" and path.exists():
+        return tomllib.loads(path.read_text())
+    bundled = resources.files(_BUNDLED_PRESETS_PACKAGE) / f"{name_or_path}.toml"
+    if not bundled.is_file():
+        raise FileNotFoundError(
+            f"No preset {name_or_path!r}. Bundled: {list_bundled_presets()}. "
+            f"Or pass a path to a .toml file."
+        )
+    return tomllib.loads(bundled.read_text())
+
+
+def _preset_name(name_or_path: str) -> str:
+    return Path(name_or_path).stem if name_or_path.endswith(".toml") else name_or_path
+
+
+def _apply_overrides(raw: dict[str, Any], overrides: list[str]) -> dict[str, Any]:
+    for spec in overrides:
+        if "=" not in spec:
+            raise ValueError(f"--set expects KEY=VALUE, got {spec!r}")
+        key, value = spec.split("=", 1)
+        _set_dotted(raw, key.strip(), _coerce(value))
+    return raw
+
+
+def _set_dotted(obj: dict[str, Any], dotted: str, value: Any) -> None:
+    """Set ``obj`` at ``a.b.c`` to ``value``. Job name lookup is allowed under ``jobs``."""
+    parts = dotted.split(".")
+    cursor: Any = obj
+    for i, part in enumerate(parts[:-1]):
+        cursor = _index(cursor, part, where=".".join(parts[: i + 1]))
+    leaf_parent = cursor
+    leaf_key = parts[-1]
+    if isinstance(leaf_parent, list):
+        leaf_parent[_find_in_list(leaf_parent, leaf_key, where=dotted)] = value
+    else:
+        leaf_parent[leaf_key] = value
+
+
+def _index(cursor: Any, part: str, *, where: str) -> Any:
+    if isinstance(cursor, list):
+        return cursor[_find_in_list(cursor, part, where=where)]
+    if isinstance(cursor, dict):
+        if part not in cursor:
+            cursor[part] = {}
+        return cursor[part]
+    raise TypeError(f"Cannot descend into {type(cursor).__name__} at {where!r}")
+
+
+def _find_in_list(items: list[Any], key: str, *, where: str) -> int:
+    if key.isdigit() or (key.startswith("-") and key[1:].isdigit()):
+        return int(key)
+    for i, item in enumerate(items):
+        if isinstance(item, dict) and item.get("name") == key:
+            return i
+    raise KeyError(f"No list element named {key!r} at {where!r}")
+
+
+def _coerce(value: str) -> Any:
+    if value.lower() in ("true", "false"):
+        return value.lower() == "true"
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    return value
+
+
+def _resolve_variables(raw: dict[str, Any]) -> dict[str, Any]:
+    """Expand ``${VAR}`` in every string. Env wins; defaults block fills gaps.
+
+    Defaults are resolved in TOML order, so later defaults can reference earlier ones
+    (e.g. ``PROTEINS_CSV = "${DATA_DIR}/proteins.csv"``).
+    """
+    defaults: dict[str, str] = dict(raw.get("defaults", {}))
+    accumulated: dict[str, str] = dict(os.environ)
+    resolved_defaults: dict[str, str] = {}
+    for key, default_value in defaults.items():
+        if key in os.environ:
+            resolved_defaults[key] = os.environ[key]
+        else:
+            resolved_defaults[key] = _expand(default_value, accumulated)
+        accumulated[key] = resolved_defaults[key]
+    resolved = _walk(raw, accumulated)
+    resolved["defaults"] = resolved_defaults
+    return resolved
+
+
+def _walk(obj: Any, env: dict[str, str]) -> Any:
+    if isinstance(obj, dict):
+        return {k: _walk(v, env) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_walk(item, env) for item in obj]
+    if isinstance(obj, str):
+        return _expand(obj, env)
+    return obj
+
+
+def _expand(text: str, env: dict[str, str]) -> str:
+    def repl(match: re.Match[str]) -> str:
+        var = match.group(1)
+        if var not in env:
+            raise KeyError(f"Undefined variable ${{{var}}} in preset (no env var, no default)")
+        return env[var]
+
+    prev = None
+    current = text
+    while prev != current:
+        prev = current
+        current = _VAR_PATTERN.sub(repl, current)
+    return current
+
+
+def _build_preset(*, name: str, raw: dict[str, Any]) -> Preset:
+    raw_jobs = raw.get("jobs", [])
+    if not isinstance(raw_jobs, list):
+        raise ValueError(f"Preset {name!r}: 'jobs' must be a list")
+    jobs = [
+        Job(
+            name=str(j["name"]),
+            env=str(j["env"]),
+            gpus=str(j["gpus"]),
+            output_subdir=str(j["output_subdir"]),
+            args=dict(j.get("args", {})),
+        )
+        for j in raw_jobs
+    ]
+    return Preset(
+        name=name,
+        description=str(raw.get("description", "")),
+        defaults=dict(raw.get("defaults", {})),
+        shared_args=dict(raw.get("shared_args", {})),
+        jobs=jobs,
+    )

--- a/src/sampleworks/runs/presets/all_models.toml
+++ b/src/sampleworks/runs/presets/all_models.toml
@@ -1,9 +1,9 @@
 description = "Run all 4 model grid searches in parallel across 8 GPUs (boltz2 X-ray, boltz2 MD, RF3, Protenix)."
 
 [defaults]
-DATA_DIR = "/data/input"
-RESULTS_DIR = "/data/results"
-MSA_CACHE_DIR = "${HOME}/.sampleworks/msa"
+DATA_DIR = "/mnt/diffuse-shared/raw/sampleworks/initial_dataset_40"
+RESULTS_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_results/all_models"
+MSA_CACHE_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_msa_cache"
 PROTEINS_CSV = "${DATA_DIR}/proteins.csv"
 
 [shared_args]

--- a/src/sampleworks/runs/presets/all_models.toml
+++ b/src/sampleworks/runs/presets/all_models.toml
@@ -1,0 +1,44 @@
+description = "Run all 4 model grid searches in parallel across 8 GPUs (boltz2 X-ray, boltz2 MD, RF3, Protenix)."
+
+[defaults]
+DATA_DIR = "/data/input"
+RESULTS_DIR = "/data/results"
+MSA_CACHE_DIR = "${HOME}/.sampleworks/msa"
+PROTEINS_CSV = "${DATA_DIR}/proteins.csv"
+
+[shared_args]
+proteins = "${PROTEINS_CSV}"
+scalers = "pure_guidance"
+partial-diffusion-step = 120
+ensemble-sizes = "8"
+gradient-normalization = true
+augmentation = true
+align-to-input = true
+
+[[jobs]]
+name = "boltz2_xrd"
+env = "boltz"
+gpus = "0,1"
+output_subdir = "boltz2_xrd"
+args = { model = "boltz2", method = "X-RAY DIFFRACTION", gradient-weights = "0.0 0.05 0.1 0.2 0.35 0.5" }
+
+[[jobs]]
+name = "boltz2_md"
+env = "boltz"
+gpus = "2,3"
+output_subdir = "boltz2_md"
+args = { model = "boltz2", method = "MD", gradient-weights = "0.0 0.05 0.1 0.2 0.35 0.5" }
+
+[[jobs]]
+name = "rf3"
+env = "rf3"
+gpus = "4,5"
+output_subdir = "rf3"
+args = { model = "rf3", gradient-weights = "0.0 0.005 0.01 0.02 0.035 0.05 0.1" }
+
+[[jobs]]
+name = "protenix"
+env = "protenix"
+gpus = "6,7"
+output_subdir = "protenix"
+args = { model = "protenix", gradient-weights = "0.0 0.05 0.1 0.2 0.35 0.5" }

--- a/src/sampleworks/runs/presets/all_models.toml
+++ b/src/sampleworks/runs/presets/all_models.toml
@@ -1,9 +1,9 @@
 description = "Run all 4 model grid searches in parallel across 8 GPUs (boltz2 X-ray, boltz2 MD, RF3, Protenix)."
 
 [defaults]
-DATA_DIR = "/mnt/diffuse-shared/raw/sampleworks/initial_dataset_40"
-RESULTS_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_results/all_models"
-MSA_CACHE_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_msa_cache"
+DATA_DIR = "/data/input"
+RESULTS_DIR = "/data/results/all_models"
+MSA_CACHE_DIR = "/root/.sampleworks"
 PROTEINS_CSV = "${DATA_DIR}/proteins.csv"
 
 [shared_args]

--- a/src/sampleworks/runs/presets/protenix_dual.toml
+++ b/src/sampleworks/runs/presets/protenix_dual.toml
@@ -1,0 +1,34 @@
+description = "Run Protenix tiny and mini variants in parallel (different checkpoints, same sweep)."
+
+[defaults]
+DATA_DIR = "/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps"
+RESULTS_DIR = "/data/sampleworks-exp/occ_sweep/grid_search_results"
+MSA_CACHE_DIR = "/data/sampleworks-exp/msa_cache"
+PROTEINS_CSV = "${DATA_DIR}/proteins.csv"
+PROTENIX_TINY_CHECKPOINT = "/extra_checkpoints/protenix_tiny_default_v0.5.0.pt"
+PROTENIX_MINI_CHECKPOINT = "/extra_checkpoints/protenix_mini_default_v0.5.0.pt"
+
+[shared_args]
+proteins = "${PROTEINS_CSV}"
+model = "protenix"
+scalers = "pure_guidance"
+partial-diffusion-step = 120
+ensemble-sizes = "8"
+gradient-weights = "0.0 0.05 0.1 0.2 0.35 0.5"
+gradient-normalization = true
+augmentation = true
+align-to-input = true
+
+[[jobs]]
+name = "protenix_tiny"
+env = "protenix"
+gpus = "2,3"
+output_subdir = "protenix_tiny"
+args = { model-checkpoint = "${PROTENIX_TINY_CHECKPOINT}" }
+
+[[jobs]]
+name = "protenix_mini"
+env = "protenix"
+gpus = "6,7"
+output_subdir = "protenix_mini"
+args = { model-checkpoint = "${PROTENIX_MINI_CHECKPOINT}" }

--- a/src/sampleworks/runs/presets/protenix_dual.toml
+++ b/src/sampleworks/runs/presets/protenix_dual.toml
@@ -1,9 +1,9 @@
 description = "Run Protenix tiny and mini variants in parallel (different checkpoints, same sweep)."
 
 [defaults]
-DATA_DIR = "/mnt/diffuse-shared/raw/sampleworks/initial_dataset_40_occ_sweeps"
-RESULTS_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_results/protenix_dual"
-MSA_CACHE_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_msa_cache"
+DATA_DIR = "/data/inputs"
+RESULTS_DIR = "/data/results/protenix_dual"
+MSA_CACHE_DIR = "/root/.sampleworks"
 PROTEINS_CSV = "${DATA_DIR}/proteins.csv"
 PROTENIX_TINY_CHECKPOINT = "/extra_checkpoints/protenix_tiny_default_v0.5.0.pt"
 PROTENIX_MINI_CHECKPOINT = "/extra_checkpoints/protenix_mini_default_v0.5.0.pt"

--- a/src/sampleworks/runs/presets/protenix_dual.toml
+++ b/src/sampleworks/runs/presets/protenix_dual.toml
@@ -1,9 +1,9 @@
 description = "Run Protenix tiny and mini variants in parallel (different checkpoints, same sweep)."
 
 [defaults]
-DATA_DIR = "/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps"
-RESULTS_DIR = "/data/sampleworks-exp/occ_sweep/grid_search_results"
-MSA_CACHE_DIR = "/data/sampleworks-exp/msa_cache"
+DATA_DIR = "/mnt/diffuse-shared/raw/sampleworks/initial_dataset_40_occ_sweeps"
+RESULTS_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_results/protenix_dual"
+MSA_CACHE_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_msa_cache"
 PROTEINS_CSV = "${DATA_DIR}/proteins.csv"
 PROTENIX_TINY_CHECKPOINT = "/extra_checkpoints/protenix_tiny_default_v0.5.0.pt"
 PROTENIX_MINI_CHECKPOINT = "/extra_checkpoints/protenix_mini_default_v0.5.0.pt"

--- a/src/sampleworks/runs/presets/rf3_partial.toml
+++ b/src/sampleworks/runs/presets/rf3_partial.toml
@@ -1,9 +1,9 @@
 description = "RF3 partial-diffusion canonical occ-sweep on a single GPU (7 gradient weights)."
 
 [defaults]
-DATA_DIR = "/mnt/diffuse-shared/raw/sampleworks/initial_dataset_40_occ_sweeps"
-RESULTS_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_results/rf3_partial"
-MSA_CACHE_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_msa_cache"
+DATA_DIR = "/data/inputs"
+RESULTS_DIR = "/data/results/rf3_partial"
+MSA_CACHE_DIR = "/root/.sampleworks"
 PROTEINS_CSV = "${DATA_DIR}/proteins.csv"
 RF3_CHECKPOINT = "/checkpoints/rf3_foundry_01_24_latest.ckpt"
 

--- a/src/sampleworks/runs/presets/rf3_partial.toml
+++ b/src/sampleworks/runs/presets/rf3_partial.toml
@@ -1,9 +1,9 @@
 description = "RF3 partial-diffusion canonical occ-sweep on a single GPU (7 gradient weights)."
 
 [defaults]
-DATA_DIR = "/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps"
-RESULTS_DIR = "${HOME}/sampleworks-exp/occ_sweep/grid_search_results"
-MSA_CACHE_DIR = "${HOME}/sampleworks-exp/msa_cache"
+DATA_DIR = "/mnt/diffuse-shared/raw/sampleworks/initial_dataset_40_occ_sweeps"
+RESULTS_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_results/rf3_partial"
+MSA_CACHE_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_msa_cache"
 PROTEINS_CSV = "${DATA_DIR}/proteins.csv"
 RF3_CHECKPOINT = "/checkpoints/rf3_foundry_01_24_latest.ckpt"
 

--- a/src/sampleworks/runs/presets/rf3_partial.toml
+++ b/src/sampleworks/runs/presets/rf3_partial.toml
@@ -1,0 +1,24 @@
+description = "RF3 partial-diffusion canonical occ-sweep on a single GPU (7 gradient weights)."
+
+[defaults]
+DATA_DIR = "/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps"
+RESULTS_DIR = "${HOME}/sampleworks-exp/occ_sweep/grid_search_results"
+MSA_CACHE_DIR = "${HOME}/sampleworks-exp/msa_cache"
+PROTEINS_CSV = "${DATA_DIR}/proteins.csv"
+RF3_CHECKPOINT = "/checkpoints/rf3_foundry_01_24_latest.ckpt"
+
+[shared_args]
+proteins = "${PROTEINS_CSV}"
+scalers = "pure_guidance"
+partial-diffusion-step = 120
+ensemble-sizes = "8"
+gradient-normalization = true
+augmentation = true
+align-to-input = true
+
+[[jobs]]
+name = "rf3"
+env = "rf3"
+gpus = "4"
+output_subdir = "rf3"
+args = { model = "rf3", gradient-weights = "0.0 0.005 0.01 0.02 0.035 0.05 0.1", model-checkpoint = "${RF3_CHECKPOINT}" }

--- a/src/sampleworks/runs/presets/rf3_partial_chiral_off.toml
+++ b/src/sampleworks/runs/presets/rf3_partial_chiral_off.toml
@@ -1,9 +1,9 @@
 description = "RF3 occ-sweep with --disable-chiral-features and a wider 10-weight sweep."
 
 [defaults]
-DATA_DIR = "/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps"
-RESULTS_DIR = "/data/sampleworks-exp/occ_sweep/grid_search_results_rf3_chiral_off"
-MSA_CACHE_DIR = "${HOME}/sampleworks-exp/msa_cache"
+DATA_DIR = "/mnt/diffuse-shared/raw/sampleworks/initial_dataset_40_occ_sweeps"
+RESULTS_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_results/rf3_partial_chiral_off"
+MSA_CACHE_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_msa_cache"
 PROTEINS_CSV = "${DATA_DIR}/proteins.csv"
 RF3_CHECKPOINT = "/checkpoints/rf3_foundry_01_24_latest.ckpt"
 

--- a/src/sampleworks/runs/presets/rf3_partial_chiral_off.toml
+++ b/src/sampleworks/runs/presets/rf3_partial_chiral_off.toml
@@ -1,9 +1,9 @@
 description = "RF3 occ-sweep with --disable-chiral-features and a wider 10-weight sweep."
 
 [defaults]
-DATA_DIR = "/mnt/diffuse-shared/raw/sampleworks/initial_dataset_40_occ_sweeps"
-RESULTS_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_results/rf3_partial_chiral_off"
-MSA_CACHE_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_msa_cache"
+DATA_DIR = "/data/inputs"
+RESULTS_DIR = "/data/results/rf3_partial_chiral_off"
+MSA_CACHE_DIR = "/root/.sampleworks"
 PROTEINS_CSV = "${DATA_DIR}/proteins.csv"
 RF3_CHECKPOINT = "/checkpoints/rf3_foundry_01_24_latest.ckpt"
 

--- a/src/sampleworks/runs/presets/rf3_partial_chiral_off.toml
+++ b/src/sampleworks/runs/presets/rf3_partial_chiral_off.toml
@@ -1,0 +1,26 @@
+description = "RF3 occ-sweep with --disable-chiral-features and a wider 10-weight sweep."
+
+[defaults]
+DATA_DIR = "/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps"
+RESULTS_DIR = "/data/sampleworks-exp/occ_sweep/grid_search_results_rf3_chiral_off"
+MSA_CACHE_DIR = "${HOME}/sampleworks-exp/msa_cache"
+PROTEINS_CSV = "${DATA_DIR}/proteins.csv"
+RF3_CHECKPOINT = "/checkpoints/rf3_foundry_01_24_latest.ckpt"
+
+[shared_args]
+proteins = "${PROTEINS_CSV}"
+scalers = "pure_guidance"
+partial-diffusion-step = 120
+ensemble-sizes = "8"
+gradient-normalization = true
+augmentation = true
+align-to-input = true
+force-all = true
+disable-chiral-features = true
+
+[[jobs]]
+name = "rf3"
+env = "rf3"
+gpus = "5"
+output_subdir = "."
+args = { model = "rf3", gradient-weights = "0.0 0.005 0.01 0.02 0.035 0.05 0.1 0.2 0.35 0.5", model-checkpoint = "${RF3_CHECKPOINT}" }

--- a/src/sampleworks/runs/presets/rf3_partial_chiral_off.toml
+++ b/src/sampleworks/runs/presets/rf3_partial_chiral_off.toml
@@ -22,5 +22,5 @@ disable-chiral-features = true
 name = "rf3"
 env = "rf3"
 gpus = "5"
-output_subdir = "."
+output_subdir = "rf3"
 args = { model = "rf3", gradient-weights = "0.0 0.005 0.01 0.02 0.035 0.05 0.1 0.2 0.35 0.5", model-checkpoint = "${RF3_CHECKPOINT}" }

--- a/src/sampleworks/runs/presets/rf3_protenix.toml
+++ b/src/sampleworks/runs/presets/rf3_protenix.toml
@@ -1,9 +1,9 @@
 description = "RF3 + Protenix combo on the occ-sweep dataset (RF3 on GPUs 0-3, Protenix on 4-7)."
 
 [defaults]
-DATA_DIR = "/mnt/diffuse-shared/raw/sampleworks/initial_dataset_40_occ_sweeps"
-RESULTS_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_results/rf3_protenix"
-MSA_CACHE_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_msa_cache"
+DATA_DIR = "/data/inputs"
+RESULTS_DIR = "/data/results/rf3_protenix"
+MSA_CACHE_DIR = "/root/.sampleworks"
 PROTEINS_CSV = "${DATA_DIR}/proteins.csv"
 
 [shared_args]

--- a/src/sampleworks/runs/presets/rf3_protenix.toml
+++ b/src/sampleworks/runs/presets/rf3_protenix.toml
@@ -1,9 +1,9 @@
 description = "RF3 + Protenix combo on the occ-sweep dataset (RF3 on GPUs 0-3, Protenix on 4-7)."
 
 [defaults]
-DATA_DIR = "/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps"
-RESULTS_DIR = "${HOME}/sampleworks-exp/occ_sweep/grid_search_results"
-MSA_CACHE_DIR = "${HOME}/sampleworks-exp/msa_cache"
+DATA_DIR = "/mnt/diffuse-shared/raw/sampleworks/initial_dataset_40_occ_sweeps"
+RESULTS_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_results/rf3_protenix"
+MSA_CACHE_DIR = "/mnt/diffuse-shared/raw/sampleworks/actl_msa_cache"
 PROTEINS_CSV = "${DATA_DIR}/proteins.csv"
 
 [shared_args]

--- a/src/sampleworks/runs/presets/rf3_protenix.toml
+++ b/src/sampleworks/runs/presets/rf3_protenix.toml
@@ -1,0 +1,29 @@
+description = "RF3 + Protenix combo on the occ-sweep dataset (RF3 on GPUs 0-3, Protenix on 4-7)."
+
+[defaults]
+DATA_DIR = "/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps"
+RESULTS_DIR = "${HOME}/sampleworks-exp/occ_sweep/grid_search_results"
+MSA_CACHE_DIR = "${HOME}/sampleworks-exp/msa_cache"
+PROTEINS_CSV = "${DATA_DIR}/proteins.csv"
+
+[shared_args]
+proteins = "${PROTEINS_CSV}"
+scalers = "pure_guidance"
+ensemble-sizes = "8"
+gradient-normalization = true
+augmentation = true
+align-to-input = true
+
+[[jobs]]
+name = "rf3"
+env = "rf3"
+gpus = "0,1,2,3"
+output_subdir = "rf3"
+args = { model = "rf3", gradient-weights = "0.0 0.01 0.02 0.05 0.1" }
+
+[[jobs]]
+name = "protenix"
+env = "protenix"
+gpus = "4,5,6,7"
+output_subdir = "protenix"
+args = { model = "protenix", partial-diffusion-step = 120, gradient-weights = "0.0 0.1 0.2 0.5" }

--- a/src/sampleworks/runs/runner.py
+++ b/src/sampleworks/runs/runner.py
@@ -64,8 +64,24 @@ def run(preset: Preset, *, results_dir: Path, dry_run: bool = False) -> int:
         return 0
 
     _print_launch_summary(preset, invocations)
-    processes = [_spawn(inv) for inv in invocations]
+    processes: list[_RunningJob] = []
+    try:
+        for inv in invocations:
+            processes.append(_spawn(inv))
+    except BaseException:
+        _terminate_all(processes)
+        raise
     return _wait_all(processes)
+
+
+def _terminate_all(jobs: list[_RunningJob]) -> None:
+    """Terminate any already-launched jobs (used when a later spawn fails)."""
+    for j in jobs:
+        if j.proc.poll() is None:
+            j.proc.terminate()
+    for j in jobs:
+        j.proc.wait()
+        j.tee_thread.join()
 
 
 def _print_dry_run(inv: JobInvocation) -> None:
@@ -99,13 +115,17 @@ class _RunningJob:
 def _spawn(inv: JobInvocation) -> _RunningJob:
     inv.log_path.parent.mkdir(parents=True, exist_ok=True)
     log_file = open(inv.log_path, "wb")
-    proc = subprocess.Popen(
-        inv.argv,
-        env=inv.env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=0,
-    )
+    try:
+        proc = subprocess.Popen(
+            inv.argv,
+            env=inv.env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=0,
+        )
+    except BaseException:
+        log_file.close()
+        raise
     assert proc.stdout is not None
     thread = threading.Thread(
         target=_tee,

--- a/src/sampleworks/runs/runner.py
+++ b/src/sampleworks/runs/runner.py
@@ -18,8 +18,22 @@ from .schema import Job, Preset
 GRID_SEARCH_SCRIPT = "/app/run_grid_search.py"
 
 
-@dataclass
+@dataclass(frozen=True)
 class JobInvocation:
+    """The fully resolved command to launch for one job.
+
+    Parameters
+    ----------
+    job : Job
+        Originating :class:`Job` (kept for introspection in logs).
+    argv : list of str
+        Subprocess command line (starts with ``pixi run -e <env> python ...``).
+    env : dict of str to str
+        Process environment, including ``CUDA_VISIBLE_DEVICES``.
+    log_path : Path
+        File to tee stdout+stderr into.
+    """
+
     job: Job
     argv: list[str]
     env: dict[str, str]
@@ -27,7 +41,24 @@ class JobInvocation:
 
 
 def build_invocations(preset: Preset, *, results_dir: Path) -> list[JobInvocation]:
-    """Build the subprocess argv + env + log path for every job in the preset."""
+    """Build the subprocess invocation for every job in the preset.
+
+    Per-job ``args`` are merged on top of :attr:`Preset.shared_args`, with
+    ``--output-dir`` auto-injected from ``results_dir / job.output_subdir`` if
+    not already present.
+
+    Parameters
+    ----------
+    preset : Preset
+        Resolved preset to launch.
+    results_dir : Path
+        Root directory for outputs and per-job log files.
+
+    Returns
+    -------
+    list of JobInvocation
+        One :class:`JobInvocation` per job, in declaration order.
+    """
     invocations: list[JobInvocation] = []
     for job in preset.jobs:
         args = preset.effective_args(job)
@@ -40,6 +71,23 @@ def build_invocations(preset: Preset, *, results_dir: Path) -> list[JobInvocatio
 
 
 def _build_argv(pixi_env: str, args: dict[str, Any]) -> list[str]:
+    """Assemble the ``pixi run`` argv list for one job's args dict.
+
+    ``True`` bools become bare flags, ``False``/``None`` are dropped, all other
+    values are stringified.
+
+    Parameters
+    ----------
+    pixi_env : str
+        Pixi environment name passed to ``-e``.
+    args : dict of str to Any
+        Flag-name to value map (kebab-case keys, no leading ``--``).
+
+    Returns
+    -------
+    list of str
+        Subprocess argv.
+    """
     argv = ["pixi", "run", "-e", pixi_env, "python", GRID_SEARCH_SCRIPT]
     for key, value in args.items():
         flag = f"--{key}"
@@ -54,7 +102,26 @@ def _build_argv(pixi_env: str, args: dict[str, Any]) -> list[str]:
 
 
 def run(preset: Preset, *, results_dir: Path, dry_run: bool = False) -> int:
-    """Launch every job in parallel; tee output to per-job logs; return 0 iff all succeed."""
+    """Launch every job in parallel and wait for completion.
+
+    Stdout+stderr from each job is teed to a per-job log file under
+    ``results_dir`` and also echoed to the driver's stderr with a ``[job_name]``
+    prefix.
+
+    Parameters
+    ----------
+    preset : Preset
+        Preset to launch.
+    results_dir : Path
+        Root directory for outputs and logs. Created if missing.
+    dry_run : bool, optional
+        If True, print the resolved commands instead of launching anything.
+
+    Returns
+    -------
+    int
+        ``0`` if all jobs exited 0 (or ``dry_run`` was set), ``1`` otherwise.
+    """
     results_dir.mkdir(parents=True, exist_ok=True)
     invocations = build_invocations(preset, results_dir=results_dir)
 
@@ -75,7 +142,14 @@ def run(preset: Preset, *, results_dir: Path, dry_run: bool = False) -> int:
 
 
 def _terminate_all(jobs: list[_RunningJob]) -> None:
-    """Terminate any already-launched jobs (used when a later spawn fails)."""
+    """Terminate any already-launched jobs (used when a later spawn fails).
+
+    Parameters
+    ----------
+    jobs : list of _RunningJob
+        Jobs whose subprocesses should be SIGTERM'd, waited on, and whose tee
+        threads should be joined.
+    """
     for j in jobs:
         if j.proc.poll() is None:
             j.proc.terminate()
@@ -85,6 +159,13 @@ def _terminate_all(jobs: list[_RunningJob]) -> None:
 
 
 def _print_dry_run(inv: JobInvocation) -> None:
+    """Print the exact command for one job without launching it.
+
+    Parameters
+    ----------
+    inv : JobInvocation
+        Invocation to print.
+    """
     print(f"# job: {inv.job.name}  (env={inv.job.env}, gpus={inv.job.gpus})", file=sys.stderr)
     print(f"# log: {inv.log_path}", file=sys.stderr)
     print(f"CUDA_VISIBLE_DEVICES={inv.job.gpus} {_shell_join(inv.argv)}")
@@ -92,6 +173,15 @@ def _print_dry_run(inv: JobInvocation) -> None:
 
 
 def _print_launch_summary(preset: Preset, invocations: list[JobInvocation]) -> None:
+    """Print a banner describing what is about to be launched.
+
+    Parameters
+    ----------
+    preset : Preset
+        Preset being launched.
+    invocations : list of JobInvocation
+        Jobs about to be spawned.
+    """
     bar = "=" * 60
     print(bar, file=sys.stderr)
     print(f"preset: {preset.name}", file=sys.stderr)
@@ -105,14 +195,44 @@ def _print_launch_summary(preset: Preset, invocations: list[JobInvocation]) -> N
     print(bar, file=sys.stderr)
 
 
-@dataclass
+@dataclass(frozen=True)
 class _RunningJob:
+    """Internal handle: a spawned subprocess and its log-tee thread.
+
+    Parameters
+    ----------
+    inv : JobInvocation
+        Originating invocation.
+    proc : subprocess.Popen
+        The subprocess (PIPE'd stdout merged with stderr).
+    tee_thread : threading.Thread
+        Daemon thread copying ``proc.stdout`` to the log file and to
+        ``sys.stderr`` with a per-job prefix.
+    """
+
     inv: JobInvocation
     proc: subprocess.Popen[bytes]
     tee_thread: threading.Thread
 
 
 def _spawn(inv: JobInvocation) -> _RunningJob:
+    """Start one subprocess and a thread to tee its output.
+
+    Parameters
+    ----------
+    inv : JobInvocation
+        Invocation to spawn.
+
+    Returns
+    -------
+    _RunningJob
+        Handle covering the subprocess and the tee thread.
+
+    Raises
+    ------
+    OSError
+        Propagated if the subprocess fails to start (e.g. binary missing).
+    """
     inv.log_path.parent.mkdir(parents=True, exist_ok=True)
     log_file = open(inv.log_path, "wb")
     try:
@@ -138,6 +258,18 @@ def _spawn(inv: JobInvocation) -> _RunningJob:
 
 
 def _wait_all(jobs: list[_RunningJob]) -> int:
+    """Wait for every job to exit and aggregate their exit codes.
+
+    Parameters
+    ----------
+    jobs : list of _RunningJob
+        Jobs to wait on.
+
+    Returns
+    -------
+    int
+        ``0`` if all jobs exited 0, ``1`` if any failed.
+    """
     failures = 0
     for j in jobs:
         exit_code = j.proc.wait()
@@ -151,6 +283,18 @@ def _wait_all(jobs: list[_RunningJob]) -> int:
 
 
 def _tee(prefix: str, src: Any, dest: Any) -> None:
+    """Copy bytes from ``src`` to ``dest`` and to stderr with a label.
+
+    Parameters
+    ----------
+    prefix : str
+        Per-line label prepended to the stderr echo (e.g. job name).
+    src : file-like
+        Readable byte stream (typically ``Popen.stdout`` with stderr merged).
+    dest : file-like
+        Writable byte stream for the on-disk log file. Closed when ``src`` is
+        exhausted.
+    """
     for line in iter(src.readline, b""):
         dest.write(line)
         dest.flush()
@@ -160,8 +304,21 @@ def _tee(prefix: str, src: Any, dest: Any) -> None:
 
 
 def _ts() -> str:
+    """Return the current local time as a ``YYYY-MM-DD HH:MM:SS`` string."""
     return time.strftime("%Y-%m-%d %H:%M:%S")
 
 
 def _shell_join(argv: list[str]) -> str:
+    """Quote ``argv`` so the result can be pasted into a POSIX shell.
+
+    Parameters
+    ----------
+    argv : list of str
+        Argument vector.
+
+    Returns
+    -------
+    str
+        Single shell-quoted command line.
+    """
     return shlex.join(argv)

--- a/src/sampleworks/runs/runner.py
+++ b/src/sampleworks/runs/runner.py
@@ -1,0 +1,146 @@
+"""Build job argv and orchestrate parallel subprocess execution."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .schema import Job, Preset
+
+GRID_SEARCH_SCRIPT = "/app/run_grid_search.py"
+
+
+@dataclass
+class JobInvocation:
+    job: Job
+    argv: list[str]
+    env: dict[str, str]
+    log_path: Path
+
+
+def build_invocations(preset: Preset, *, results_dir: Path) -> list[JobInvocation]:
+    """Build the subprocess argv + env + log path for every job in the preset."""
+    invocations: list[JobInvocation] = []
+    for job in preset.jobs:
+        args = preset.effective_args(job)
+        args.setdefault("output-dir", str(results_dir / job.output_subdir))
+        argv = _build_argv(job.env, args)
+        env = {**os.environ, "CUDA_VISIBLE_DEVICES": job.gpus}
+        log_path = results_dir / f"{job.name}_run.log"
+        invocations.append(JobInvocation(job=job, argv=argv, env=env, log_path=log_path))
+    return invocations
+
+
+def _build_argv(pixi_env: str, args: dict[str, Any]) -> list[str]:
+    argv = ["pixi", "run", "-e", pixi_env, "python", GRID_SEARCH_SCRIPT]
+    for key, value in args.items():
+        flag = f"--{key}"
+        if isinstance(value, bool):
+            if value:
+                argv.append(flag)
+        elif value is None:
+            continue
+        else:
+            argv.extend([flag, str(value)])
+    return argv
+
+
+def run(preset: Preset, *, results_dir: Path, dry_run: bool = False) -> int:
+    """Launch every job in parallel; tee output to per-job logs; return 0 iff all succeed."""
+    results_dir.mkdir(parents=True, exist_ok=True)
+    invocations = build_invocations(preset, results_dir=results_dir)
+
+    if dry_run:
+        for inv in invocations:
+            _print_dry_run(inv)
+        return 0
+
+    _print_launch_summary(preset, invocations)
+    processes = [_spawn(inv) for inv in invocations]
+    return _wait_all(processes)
+
+
+def _print_dry_run(inv: JobInvocation) -> None:
+    print(f"# job: {inv.job.name}  (env={inv.job.env}, gpus={inv.job.gpus})", file=sys.stderr)
+    print(f"# log: {inv.log_path}", file=sys.stderr)
+    print(f"CUDA_VISIBLE_DEVICES={inv.job.gpus} {_shell_join(inv.argv)}")
+    print(file=sys.stderr)
+
+
+def _print_launch_summary(preset: Preset, invocations: list[JobInvocation]) -> None:
+    bar = "=" * 60
+    print(bar, file=sys.stderr)
+    print(f"preset: {preset.name}", file=sys.stderr)
+    if preset.description:
+        print(f"  {preset.description}", file=sys.stderr)
+    for inv in invocations:
+        print(
+            f"  - {inv.job.name}: env={inv.job.env}, gpus={inv.job.gpus}, log={inv.log_path}",
+            file=sys.stderr,
+        )
+    print(bar, file=sys.stderr)
+
+
+@dataclass
+class _RunningJob:
+    inv: JobInvocation
+    proc: subprocess.Popen[bytes]
+    tee_thread: threading.Thread
+
+
+def _spawn(inv: JobInvocation) -> _RunningJob:
+    inv.log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_file = open(inv.log_path, "wb")
+    proc = subprocess.Popen(
+        inv.argv,
+        env=inv.env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=0,
+    )
+    assert proc.stdout is not None
+    thread = threading.Thread(
+        target=_tee,
+        args=(inv.job.name, proc.stdout, log_file),
+        daemon=True,
+    )
+    thread.start()
+    print(f"[{_ts()}] launched {inv.job.name} (pid {proc.pid})", file=sys.stderr)
+    return _RunningJob(inv=inv, proc=proc, tee_thread=thread)
+
+
+def _wait_all(jobs: list[_RunningJob]) -> int:
+    failures = 0
+    for j in jobs:
+        exit_code = j.proc.wait()
+        j.tee_thread.join()
+        if exit_code == 0:
+            print(f"[{_ts()}] {j.inv.job.name} succeeded", file=sys.stderr)
+        else:
+            print(f"[{_ts()}] {j.inv.job.name} FAILED (exit {exit_code})", file=sys.stderr)
+            failures += 1
+    return 0 if failures == 0 else 1
+
+
+def _tee(prefix: str, src: Any, dest: Any) -> None:
+    for line in iter(src.readline, b""):
+        dest.write(line)
+        dest.flush()
+        sys.stderr.write(f"[{prefix}] {line.decode('utf-8', errors='replace')}")
+        sys.stderr.flush()
+    dest.close()
+
+
+def _ts() -> str:
+    return time.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _shell_join(argv: list[str]) -> str:
+    return shlex.join(argv)

--- a/src/sampleworks/runs/runner.py
+++ b/src/sampleworks/runs/runner.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from .schema import Job, Preset
 
+
 GRID_SEARCH_SCRIPT = "/app/run_grid_search.py"
 
 

--- a/src/sampleworks/runs/runner.py
+++ b/src/sampleworks/runs/runner.py
@@ -32,12 +32,16 @@ class JobInvocation:
         Process environment, including ``CUDA_VISIBLE_DEVICES``.
     log_path : Path
         File to tee stdout+stderr into.
+    output_dir : Path
+        Resolved ``--output-dir`` value (mkdir'd by the runner before launch
+        because ``run_grid_search.py`` assumes its existence).
     """
 
     job: Job
     argv: list[str]
     env: dict[str, str]
     log_path: Path
+    output_dir: Path
 
 
 def build_invocations(preset: Preset, *, results_dir: Path) -> list[JobInvocation]:
@@ -66,7 +70,10 @@ def build_invocations(preset: Preset, *, results_dir: Path) -> list[JobInvocatio
         argv = _build_argv(job.env, args)
         env = {**os.environ, "CUDA_VISIBLE_DEVICES": job.gpus}
         log_path = results_dir / f"{job.name}_run.log"
-        invocations.append(JobInvocation(job=job, argv=argv, env=env, log_path=log_path))
+        output_dir = Path(args["output-dir"])
+        invocations.append(
+            JobInvocation(job=job, argv=argv, env=env, log_path=log_path, output_dir=output_dir)
+        )
     return invocations
 
 
@@ -234,6 +241,7 @@ def _spawn(inv: JobInvocation) -> _RunningJob:
         Propagated if the subprocess fails to start (e.g. binary missing).
     """
     inv.log_path.parent.mkdir(parents=True, exist_ok=True)
+    inv.output_dir.mkdir(parents=True, exist_ok=True)
     log_file = open(inv.log_path, "wb")
     try:
         proc = subprocess.Popen(

--- a/src/sampleworks/runs/schema.py
+++ b/src/sampleworks/runs/schema.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+
 VALID_PIXI_ENVS = ("boltz", "protenix", "rf3")
 
 

--- a/src/sampleworks/runs/schema.py
+++ b/src/sampleworks/runs/schema.py
@@ -14,8 +14,37 @@ from typing import Any
 VALID_PIXI_ENVS = ("boltz", "protenix", "rf3")
 
 
-@dataclass
+@dataclass(frozen=True)
 class Job:
+    """One parallel `run_grid_search.py` invocation within a preset.
+
+    Parameters
+    ----------
+    name : str
+        Identifier used for per-job log files and ``--only`` selection. Must be
+        unique within the parent :class:`Preset`.
+    env : str
+        Pixi environment to run the job in. Must be one of
+        :data:`VALID_PIXI_ENVS`.
+    gpus : str
+        Value to set as ``CUDA_VISIBLE_DEVICES`` for the subprocess (e.g.
+        ``"4"`` or ``"0,1"``).
+    output_subdir : str
+        Path appended to the run's ``results_dir`` to form the job's
+        ``--output-dir`` argument, when one is not given explicitly in ``args``.
+    args : dict of str to Any, optional
+        Per-job overrides merged on top of the preset's
+        :attr:`Preset.shared_args`. Keys are CLI flag names (without the
+        leading ``--``); bools become bare flags (``True``) or omitted
+        (``False``).
+
+    Raises
+    ------
+    ValueError
+        If ``env`` is not in :data:`VALID_PIXI_ENVS`, or if ``gpus`` /
+        ``output_subdir`` is empty.
+    """
+
     name: str
     env: str
     gpus: str
@@ -23,6 +52,7 @@ class Job:
     args: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        """Validate ``env`` and required string fields."""
         if self.env not in VALID_PIXI_ENVS:
             raise ValueError(
                 f"Job {self.name!r}: env must be one of {VALID_PIXI_ENVS}, got {self.env!r}"
@@ -33,8 +63,32 @@ class Job:
             raise ValueError(f"Job {self.name!r}: output_subdir must be non-empty")
 
 
-@dataclass
+@dataclass(frozen=True)
 class Preset:
+    """A named bundle of parallel jobs orchestrated as a unit.
+
+    Parameters
+    ----------
+    name : str
+        Identifier (matches the bundled TOML filename without the ``.toml``
+        suffix, or the stem of a user-supplied path).
+    description : str
+        Human-readable summary shown by ``--list`` and the launch banner.
+    defaults : dict of str to str, optional
+        Default values for ``${VAR}`` interpolation. The process environment
+        takes precedence; this block only fills in unset keys.
+    shared_args : dict of str to Any, optional
+        Args merged into every job's ``args`` before argv is built. Per-job
+        ``args`` win on collision.
+    jobs : list of Job
+        Jobs to launch in parallel. Must be non-empty and have unique names.
+
+    Raises
+    ------
+    ValueError
+        If ``jobs`` is empty or contains duplicate names.
+    """
+
     name: str
     description: str
     defaults: dict[str, str] = field(default_factory=dict)
@@ -42,6 +96,7 @@ class Preset:
     jobs: list[Job] = field(default_factory=list)
 
     def __post_init__(self) -> None:
+        """Validate the job list is non-empty and names are unique."""
         if not self.jobs:
             raise ValueError(f"Preset {self.name!r}: must declare at least one job")
         seen: set[str] = set()
@@ -51,11 +106,39 @@ class Preset:
             seen.add(job.name)
 
     def job(self, name: str) -> Job:
+        """Return the :class:`Job` with the given name.
+
+        Parameters
+        ----------
+        name : str
+            Job name to look up.
+
+        Returns
+        -------
+        Job
+            The matching job.
+
+        Raises
+        ------
+        KeyError
+            If no job has the given name.
+        """
         for j in self.jobs:
             if j.name == name:
                 return j
         raise KeyError(f"Preset {self.name!r} has no job {name!r}")
 
     def effective_args(self, job: Job) -> dict[str, Any]:
-        """Return ``shared_args`` merged with per-job overrides."""
+        """Merge :attr:`shared_args` with a job's per-job overrides.
+
+        Parameters
+        ----------
+        job : Job
+            Job whose ``args`` override the shared defaults.
+
+        Returns
+        -------
+        dict of str to Any
+            New dict; mutating it does not affect the preset.
+        """
         return {**self.shared_args, **job.args}

--- a/src/sampleworks/runs/schema.py
+++ b/src/sampleworks/runs/schema.py
@@ -1,0 +1,60 @@
+"""Dataclasses for the preset schema.
+
+A preset describes one or more parallel ``run_grid_search.py`` jobs. Each job
+is launched as ``pixi run -e <env> python /app/run_grid_search.py <args>`` with
+``CUDA_VISIBLE_DEVICES`` set to the job's GPU assignment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+VALID_PIXI_ENVS = ("boltz", "protenix", "rf3")
+
+
+@dataclass
+class Job:
+    name: str
+    env: str
+    gpus: str
+    output_subdir: str
+    args: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.env not in VALID_PIXI_ENVS:
+            raise ValueError(
+                f"Job {self.name!r}: env must be one of {VALID_PIXI_ENVS}, got {self.env!r}"
+            )
+        if not self.gpus:
+            raise ValueError(f"Job {self.name!r}: gpus must be non-empty")
+        if not self.output_subdir:
+            raise ValueError(f"Job {self.name!r}: output_subdir must be non-empty")
+
+
+@dataclass
+class Preset:
+    name: str
+    description: str
+    defaults: dict[str, str] = field(default_factory=dict)
+    shared_args: dict[str, Any] = field(default_factory=dict)
+    jobs: list[Job] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.jobs:
+            raise ValueError(f"Preset {self.name!r}: must declare at least one job")
+        seen: set[str] = set()
+        for job in self.jobs:
+            if job.name in seen:
+                raise ValueError(f"Preset {self.name!r}: duplicate job name {job.name!r}")
+            seen.add(job.name)
+
+    def job(self, name: str) -> Job:
+        for j in self.jobs:
+            if j.name == name:
+                return j
+        raise KeyError(f"Preset {self.name!r} has no job {name!r}")
+
+    def effective_args(self, job: Job) -> dict[str, Any]:
+        """Return ``shared_args`` merged with per-job overrides."""
+        return {**self.shared_args, **job.args}

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-
 from sampleworks.runs import cli
 
 

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -36,9 +36,7 @@ def test_dry_run_does_not_invoke_subprocess(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
-    exit_code = cli.main(
-        ["rf3_partial", "--dry-run", "--results-dir", str(tmp_path)]
-    )
+    exit_code = cli.main(["rf3_partial", "--dry-run", "--results-dir", str(tmp_path)])
     assert exit_code == 0
     out = capsys.readouterr().out
     assert "pixi run -e rf3 python /app/run_grid_search.py" in out

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -1,0 +1,88 @@
+"""End-to-end CLI tests (--list, --show, --dry-run, --only)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sampleworks.runs import cli
+
+
+def test_list_prints_all_bundled_presets(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = cli.main(["--list"])
+    assert exit_code == 0
+    out = capsys.readouterr().out.splitlines()
+    assert set(out) == {
+        "all_models",
+        "rf3_partial",
+        "rf3_partial_chiral_off",
+        "protenix_dual",
+        "rf3_protenix",
+    }
+
+
+def test_show_prints_resolved_preset(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    exit_code = cli.main(["rf3_partial", "--show"])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "name: rf3_partial" in out
+    assert "gradient-weights" in out
+
+
+def test_dry_run_does_not_invoke_subprocess(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    exit_code = cli.main(
+        ["rf3_partial", "--dry-run", "--results-dir", str(tmp_path)]
+    )
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "pixi run -e rf3 python /app/run_grid_search.py" in out
+    assert "CUDA_VISIBLE_DEVICES=4" in out
+
+
+def test_only_filters_to_subset(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    exit_code = cli.main(["all_models", "--only", "rf3,protenix", "--show"])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "name: rf3" in out
+    assert "name: protenix" in out
+    assert "boltz2_xrd" not in out
+    assert "boltz2_md" not in out
+
+
+def test_only_with_unknown_job_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    with pytest.raises(SystemExit, match="unknown jobs"):
+        cli.main(["all_models", "--only", "nonexistent", "--show"])
+
+
+def test_set_override_propagates_through_cli(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    exit_code = cli.main(
+        [
+            "rf3_partial",
+            "--set",
+            "jobs.rf3.args.gradient-weights=0.0 0.01",
+            "--show",
+        ]
+    )
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "0.0 0.01" in out
+
+
+def test_no_preset_and_no_list_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    with pytest.raises(SystemExit):
+        cli.main([])

--- a/tests/runs/test_loader.py
+++ b/tests/runs/test_loader.py
@@ -1,0 +1,142 @@
+"""Unit tests for sampleworks.runs.loader."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from sampleworks.runs import loader
+from sampleworks.runs.schema import Preset
+
+
+BUNDLED = ["all_models", "rf3_partial", "rf3_partial_chiral_off", "protenix_dual", "rf3_protenix"]
+
+
+def test_list_bundled_presets_returns_the_five() -> None:
+    names = loader.list_bundled_presets()
+    assert set(names) == set(BUNDLED), f"unexpected bundled presets: {names}"
+
+
+@pytest.mark.parametrize("name", BUNDLED)
+def test_each_bundled_preset_loads(name: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    preset = loader.load_preset(name)
+    assert preset.name == name
+    assert preset.jobs, f"{name} has no jobs"
+    for job in preset.jobs:
+        assert job.env in ("boltz", "protenix", "rf3")
+
+
+def test_env_var_wins_over_defaults_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    monkeypatch.setenv("DATA_DIR", "/from/env")
+    preset = loader.load_preset("rf3_partial")
+    assert preset.defaults["DATA_DIR"] == "/from/env"
+    rf3 = preset.job("rf3")
+    # PROTEINS_CSV expands to ${DATA_DIR}/proteins.csv; DATA_DIR overridden by env
+    proteins = preset.shared_args["proteins"]
+    assert proteins == "/from/env/proteins.csv"
+
+
+def test_defaults_used_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DATA_DIR", raising=False)
+    monkeypatch.setenv("HOME", "/home/test")
+    preset = loader.load_preset("rf3_partial")
+    assert preset.defaults["DATA_DIR"] == "/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps"
+
+
+def test_set_override_at_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DATA_DIR", raising=False)
+    monkeypatch.setenv("HOME", "/home/test")
+    preset = loader.load_preset("rf3_partial", overrides=["defaults.DATA_DIR=/custom"])
+    assert preset.defaults["DATA_DIR"] == "/custom"
+    assert preset.shared_args["proteins"] == "/custom/proteins.csv"
+
+
+def test_set_override_at_job_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    preset = loader.load_preset("all_models", overrides=["jobs.rf3.gpus=7"])
+    assert preset.job("rf3").gpus == "7"
+
+
+def test_set_override_at_job_by_index(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    preset = loader.load_preset("all_models", overrides=["jobs.0.gpus=9"])
+    assert preset.jobs[0].gpus == "9"
+
+
+def test_set_override_at_args_inside_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    preset = loader.load_preset(
+        "rf3_partial", overrides=["jobs.rf3.args.gradient-weights=0.0 0.01"]
+    )
+    assert preset.job("rf3").args["gradient-weights"] == "0.0 0.01"
+
+
+def test_set_coerces_bool_and_int(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    preset = loader.load_preset(
+        "rf3_partial",
+        overrides=[
+            "shared_args.gradient-normalization=false",
+            "jobs.rf3.args.partial-diffusion-step=200",
+        ],
+    )
+    assert preset.shared_args["gradient-normalization"] is False
+    # job.args["partial-diffusion-step"] doesn't exist by default in rf3_partial,
+    # but --set should still create or override it
+    assert preset.job("rf3").args["partial-diffusion-step"] == 200
+
+
+def test_load_preset_from_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    custom = tmp_path / "mycustom.toml"
+    custom.write_text(
+        'description = "custom"\n'
+        "[defaults]\n"
+        'DATA_DIR = "/x"\n'
+        "[shared_args]\n"
+        'model = "rf3"\n'
+        "[[jobs]]\n"
+        'name = "j1"\n'
+        'env = "rf3"\n'
+        'gpus = "0"\n'
+        'output_subdir = "j1"\n'
+        "args = {}\n"
+    )
+    preset = loader.load_preset(str(custom))
+    assert preset.name == "mycustom"
+    assert preset.defaults["DATA_DIR"] == "/x"
+
+
+def test_unknown_preset_raises() -> None:
+    with pytest.raises(FileNotFoundError):
+        loader.load_preset("does_not_exist")
+
+
+def test_undefined_variable_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    bad = tmp_path / "bad.toml"
+    bad.write_text(
+        '[shared_args]\nproteins = "${NEVER_DEFINED_VAR}/x"\n'
+        '[[jobs]]\nname = "j"\nenv = "rf3"\ngpus = "0"\noutput_subdir = "j"\nargs = {}\n'
+    )
+    monkeypatch.delenv("NEVER_DEFINED_VAR", raising=False)
+    with pytest.raises(KeyError, match="NEVER_DEFINED_VAR"):
+        loader.load_preset(str(bad))
+
+
+def test_set_without_equals_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    with pytest.raises(ValueError, match="KEY=VALUE"):
+        loader.load_preset("rf3_partial", overrides=["bogus_no_equals"])
+
+
+def test_bad_env_rejected(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.toml"
+    bad.write_text(
+        '[[jobs]]\nname = "j"\nenv = "not_a_real_env"\ngpus = "0"\noutput_subdir = "j"\nargs = {}\n'
+    )
+    with pytest.raises(ValueError, match="env must be one of"):
+        loader.load_preset(str(bad))

--- a/tests/runs/test_loader.py
+++ b/tests/runs/test_loader.py
@@ -40,8 +40,7 @@ def test_defaults_used_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("DATA_DIR", raising=False)
     monkeypatch.setenv("HOME", "/home/test")
     preset = loader.load_preset("rf3_partial")
-    expected = "/mnt/diffuse-shared/raw/sampleworks/initial_dataset_40_occ_sweeps"
-    assert preset.defaults["DATA_DIR"] == expected
+    assert preset.defaults["DATA_DIR"] == "/data/inputs"
 
 
 def test_set_override_at_defaults(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/runs/test_loader.py
+++ b/tests/runs/test_loader.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest
-
 from sampleworks.runs import loader
-from sampleworks.runs.schema import Preset
 
 
 BUNDLED = ["all_models", "rf3_partial", "rf3_partial_chiral_off", "protenix_dual", "rf3_protenix"]
@@ -34,7 +31,6 @@ def test_env_var_wins_over_defaults_block(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setenv("DATA_DIR", "/from/env")
     preset = loader.load_preset("rf3_partial")
     assert preset.defaults["DATA_DIR"] == "/from/env"
-    rf3 = preset.job("rf3")
     # PROTEINS_CSV expands to ${DATA_DIR}/proteins.csv; DATA_DIR overridden by env
     proteins = preset.shared_args["proteins"]
     assert proteins == "/from/env/proteins.csv"
@@ -44,7 +40,8 @@ def test_defaults_used_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("DATA_DIR", raising=False)
     monkeypatch.setenv("HOME", "/home/test")
     preset = loader.load_preset("rf3_partial")
-    assert preset.defaults["DATA_DIR"] == "/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps"
+    expected = "/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps"
+    assert preset.defaults["DATA_DIR"] == expected
 
 
 def test_set_override_at_defaults(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/runs/test_loader.py
+++ b/tests/runs/test_loader.py
@@ -130,6 +130,13 @@ def test_set_without_equals_raises(monkeypatch: pytest.MonkeyPatch) -> None:
         loader.load_preset("rf3_partial", overrides=["bogus_no_equals"])
 
 
+def test_set_with_unknown_top_level_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Typos like ``--set job.rf3.gpus=0`` (missing 's' in jobs) must not silently no-op."""
+    monkeypatch.setenv("HOME", "/home/test")
+    with pytest.raises(KeyError, match="unknown top-level key"):
+        loader.load_preset("rf3_partial", overrides=["job.rf3.gpus=0"])
+
+
 def test_bad_env_rejected(tmp_path: Path) -> None:
     bad = tmp_path / "bad.toml"
     bad.write_text(

--- a/tests/runs/test_loader.py
+++ b/tests/runs/test_loader.py
@@ -40,7 +40,7 @@ def test_defaults_used_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("DATA_DIR", raising=False)
     monkeypatch.setenv("HOME", "/home/test")
     preset = loader.load_preset("rf3_partial")
-    expected = "/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps"
+    expected = "/mnt/diffuse-shared/raw/sampleworks/initial_dataset_40_occ_sweeps"
     assert preset.defaults["DATA_DIR"] == expected
 
 

--- a/tests/runs/test_runner.py
+++ b/tests/runs/test_runner.py
@@ -1,0 +1,111 @@
+"""Unit tests for sampleworks.runs.runner argv builder."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sampleworks.runs import loader, runner
+
+
+def test_argv_for_rf3_partial_matches_bash(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Faithful translation: argv should match the canonical rf3_partial bash invocation."""
+    monkeypatch.setenv("HOME", "/home/test")
+    monkeypatch.delenv("DATA_DIR", raising=False)
+    monkeypatch.delenv("RESULTS_DIR", raising=False)
+    preset = loader.load_preset("rf3_partial")
+    invocations = runner.build_invocations(preset, results_dir=Path("/results"))
+
+    assert len(invocations) == 1
+    inv = invocations[0]
+    assert inv.job.name == "rf3"
+    assert inv.env["CUDA_VISIBLE_DEVICES"] == "4"
+    assert inv.log_path == Path("/results/rf3_run.log")
+
+    argv = inv.argv
+    assert argv[:6] == ["pixi", "run", "-e", "rf3", "python", "/app/run_grid_search.py"]
+    pairs = _argv_to_dict(argv[6:])
+    assert pairs["--proteins"] == (
+        "/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps/proteins.csv"
+    )
+    assert pairs["--model"] == "rf3"
+    assert pairs["--scalers"] == "pure_guidance"
+    assert pairs["--partial-diffusion-step"] == "120"
+    assert pairs["--ensemble-sizes"] == "8"
+    assert pairs["--gradient-weights"] == "0.0 0.005 0.01 0.02 0.035 0.05 0.1"
+    assert pairs["--model-checkpoint"] == "/checkpoints/rf3_foundry_01_24_latest.ckpt"
+    assert pairs["--output-dir"] == "/results/rf3"
+    # store_true flags appear as bare keys (value=True in our dict)
+    assert pairs["--gradient-normalization"] is True
+    assert pairs["--augmentation"] is True
+    assert pairs["--align-to-input"] is True
+
+
+def test_argv_omits_false_bool_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    preset = loader.load_preset(
+        "rf3_partial", overrides=["shared_args.gradient-normalization=false"]
+    )
+    inv = runner.build_invocations(preset, results_dir=Path("/results"))[0]
+    assert "--gradient-normalization" not in inv.argv
+
+
+def test_explicit_output_dir_in_args_wins_over_subdir_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    custom = tmp_path / "custom.toml"
+    custom.write_text(
+        "[shared_args]\n"
+        '[[jobs]]\nname = "j"\nenv = "rf3"\ngpus = "0"\noutput_subdir = "sub"\n'
+        'args = { "output-dir" = "/explicit/path" }\n'
+    )
+    preset = loader.load_preset(str(custom))
+    inv = runner.build_invocations(preset, results_dir=Path("/results"))[0]
+    pairs = _argv_to_dict(inv.argv[6:])
+    assert pairs["--output-dir"] == "/explicit/path"
+
+
+def test_all_models_has_four_jobs_with_distinct_gpus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    preset = loader.load_preset("all_models")
+    invocations = runner.build_invocations(preset, results_dir=Path("/r"))
+    assert [i.job.name for i in invocations] == ["boltz2_xrd", "boltz2_md", "rf3", "protenix"]
+    gpu_assignments = [i.env["CUDA_VISIBLE_DEVICES"] for i in invocations]
+    assert gpu_assignments == ["0,1", "2,3", "4,5", "6,7"]
+
+
+def test_protenix_dual_uses_different_checkpoints(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    preset = loader.load_preset("protenix_dual")
+    invocations = runner.build_invocations(preset, results_dir=Path("/r"))
+    pairs = [_argv_to_dict(i.argv[6:]) for i in invocations]
+    assert pairs[0]["--model-checkpoint"] == "/extra_checkpoints/protenix_tiny_default_v0.5.0.pt"
+    assert pairs[1]["--model-checkpoint"] == "/extra_checkpoints/protenix_mini_default_v0.5.0.pt"
+
+
+def test_rf3_partial_chiral_off_flag_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", "/home/test")
+    preset = loader.load_preset("rf3_partial_chiral_off")
+    inv = runner.build_invocations(preset, results_dir=Path("/r"))[0]
+    assert "--disable-chiral-features" in inv.argv
+    assert "--force-all" in inv.argv
+
+
+def _argv_to_dict(tail: list[str]) -> dict[str, object]:
+    """Turn ``[--a, 1, --b, --c, 2]`` into ``{'--a': '1', '--b': True, '--c': '2'}``."""
+    out: dict[str, object] = {}
+    i = 0
+    while i < len(tail):
+        flag = tail[i]
+        assert flag.startswith("--"), f"unexpected positional: {flag}"
+        if i + 1 < len(tail) and not tail[i + 1].startswith("--"):
+            out[flag] = tail[i + 1]
+            i += 2
+        else:
+            out[flag] = True
+            i += 1
+    return out

--- a/tests/runs/test_runner.py
+++ b/tests/runs/test_runner.py
@@ -25,9 +25,7 @@ def test_argv_for_rf3_partial_matches_bash(monkeypatch: pytest.MonkeyPatch) -> N
     argv = inv.argv
     assert argv[:6] == ["pixi", "run", "-e", "rf3", "python", "/app/run_grid_search.py"]
     pairs = _argv_to_dict(argv[6:])
-    assert pairs["--proteins"] == (
-        "/mnt/diffuse-shared/raw/sampleworks/initial_dataset_40_occ_sweeps/proteins.csv"
-    )
+    assert pairs["--proteins"] == "/data/inputs/proteins.csv"
     assert pairs["--model"] == "rf3"
     assert pairs["--scalers"] == "pure_guidance"
     assert pairs["--partial-diffusion-step"] == "120"

--- a/tests/runs/test_runner.py
+++ b/tests/runs/test_runner.py
@@ -26,7 +26,7 @@ def test_argv_for_rf3_partial_matches_bash(monkeypatch: pytest.MonkeyPatch) -> N
     assert argv[:6] == ["pixi", "run", "-e", "rf3", "python", "/app/run_grid_search.py"]
     pairs = _argv_to_dict(argv[6:])
     assert pairs["--proteins"] == (
-        "/mnt/diffuse-private/raw/sampleworks/initial_dataset_40_occ_sweeps/proteins.csv"
+        "/mnt/diffuse-shared/raw/sampleworks/initial_dataset_40_occ_sweeps/proteins.csv"
     )
     assert pairs["--model"] == "rf3"
     assert pairs["--scalers"] == "pure_guidance"

--- a/tests/runs/test_runner.py
+++ b/tests/runs/test_runner.py
@@ -92,6 +92,27 @@ def test_rf3_partial_chiral_off_flag_present(monkeypatch: pytest.MonkeyPatch) ->
     assert "--force-all" in inv.argv
 
 
+def test_build_invocations_records_output_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`run_grid_search.py` assumes its --output-dir exists; the runner must mkdir it."""
+    monkeypatch.setenv("HOME", "/home/test")
+    preset = loader.load_preset("rf3_partial")
+    inv = runner.build_invocations(preset, results_dir=Path("/r"))[0]
+    assert inv.output_dir == Path("/r/rf3")
+
+
+def test_dry_run_does_not_create_directories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--dry-run prints commands but never touches the filesystem."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    results_dir = tmp_path / "results"
+    preset = loader.load_preset("rf3_partial")
+    runner.run(preset, results_dir=results_dir, dry_run=True)
+    # results_dir gets created by run() (for log file location) but per-job
+    # output subdirs must NOT exist after dry-run.
+    assert not (results_dir / "rf3").exists()
+
+
 def _argv_to_dict(tail: list[str]) -> dict[str, object]:
     """Turn ``[--a, 1, --b, --c, 2]`` into ``{'--a': '1', '--b': True, '--c': '2'}``."""
     out: dict[str, object] = {}

--- a/tests/runs/test_runner.py
+++ b/tests/runs/test_runner.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-
 from sampleworks.runs import loader, runner
 
 


### PR DESCRIPTION
## Summary

- New `sampleworks-runs` CLI at `src/sampleworks/runs/` that launches parallel `run_grid_search.py` jobs from a single TOML preset; each preset declares its jobs (pixi env, GPU assignment, args), the runner sets `CUDA_VISIBLE_DEVICES`, shells out via `pixi run -e <env>`, tees per-job logs, and aggregates exit codes
- Five bundled presets cover the canonical multi-model sweeps: `all_models`, `rf3_partial`, `rf3_partial_chiral_off`, `protenix_dual`, `rf3_protenix`
- Dotted-path `--set` overrides for fast iteration without editing the TOML (e.g. `--set jobs.rf3.args.gradient-weights="0.0 0.01"`)
- Pure stdlib (`tomllib` + dataclasses + argparse + subprocess), no new deps

## Motivation

Today's iteration loop on canonical sweeps means copy-pasting a ~50-line bash script and tweaking ~5 lines of substance buried in `PIDS=();wait` boilerplate. With TOML presets the substance is 5 lines of data, and `--set` overrides let you sweep without editing the file at all.

## Usage

```bash
pixi run -e rf3 sampleworks-runs --list                            # bundled presets
pixi run -e rf3 sampleworks-runs rf3_partial                       # run
pixi run -e rf3 sampleworks-runs rf3_partial --show                # inspect resolved
pixi run -e rf3 sampleworks-runs rf3_partial --dry-run             # print commands
pixi run -e rf3 sampleworks-runs all_models --only rf3,protenix    # subset jobs

# Override anything without editing TOML:
pixi run -e rf3 sampleworks-runs rf3_partial \
    --set jobs.rf3.gpus=7 \
    --set jobs.rf3.args.gradient-weights="0.0 0.01 0.02"
```

Bundled presets live in `src/sampleworks/runs/presets/*.toml`; users can also pass a path to any `.toml` file.

## Test plan

- [x] 31 unit tests under `tests/runs/` cover argv builder, dotted-path overrides, `--only` filter, env-var precedence over `[defaults]`, validation
- [x] `sampleworks-runs --list` returns the five bundled presets
- [x] `sampleworks-runs rf3_partial --dry-run` emits the expected `pixi run -e rf3 python /app/run_grid_search.py ...` argv with `CUDA_VISIBLE_DEVICES=4`
- [ ] In-pod smoke test: `sampleworks-runs rf3_partial --dry-run` on the actual sampleworks image
- [ ] Live test: `sampleworks-runs rf3_partial` runs a single RF3 GPU job to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New installable console command for running parallel, preset-driven experiments: list/show presets, filter jobs, apply dotted overrides, dry-run, and launch per-job processes with individual logs; bundled presets included.

* **Documentation**
  * Added README section describing presets, CLI usage, override syntax, env-var defaults, and examples.

* **Tests**
  * Added end-to-end tests covering preset loading, overrides, CLI behavior, dry-run output, filtering, and invocation/log generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diff-use/sampleworks/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->