### PR TITLE
fix: quick patch to enforce that the ref chain is the one assigned to…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,8 +222,8 @@ release_data/
 checkpoints/
 
 # Large results from runs
-grid_search_results/
-outputs/
+grid_search_results*/
+output*/
 initial_dataset_40*/
 *.tar.gz
 *.tgz

--- a/scripts/patch_output_cif_files.py
+++ b/scripts/patch_output_cif_files.py
@@ -159,7 +159,10 @@ def patch_individual_cif_file(
         if cif_key[0] != ref_key[0]:
             msg = f"Chain mismatch while remapping residues for {cif_path} vs {reference_path}"
             logger.error(msg)
-            return msg
+            # return msg
+            # TODO: fix chain mismatches upstream (protenix json creation needs update)
+            # this breaks multi-chain stuff for now
+
         mapping[cif_key] = ref_key[1]
 
     atom_keys = list(zip(asym_unit.chain_id.tolist(), asym_unit.res_id.tolist()))


### PR DESCRIPTION
… the cif file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control ignore patterns for large run outputs
  * Modified internal structure file processing to handle chain identifier mismatches

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/diff-use/sampleworks/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->