### PR TITLE
Run docker workflow on Astera builder

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,7 @@ env:
 
   ASTERA_REGISTRY: harbor.astera.sh
   ASTERA_IMAGE_NAME: library/pixi-with-checkpoints
+  SKOPEO_IMAGE: quay.io/skopeo/stable@sha256:2bfc4bce3224a5940708fbaf7c161a2ef395ab272b568b3abfaf3ca48164b63d
   # Update this only when the Astera overlay needs a newer EXT CLI; otherwise the
   # repo variable can override it without changing this workflow.
   EXT_CLI_IMAGE: ${{ vars.EXT_CLI_IMAGE || 'harbor.astera.sh/library/ext-cli:sha-724abde27fdfa15b23adb112d2e1dc83dd533a57' }}
@@ -32,18 +33,13 @@ env:
 jobs:
   sync_checkpoints:
     name: Sync checkpoints to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: astera-sh-builder
     permissions:
       contents: read
     outputs:
       checkpoints_image: ${{ steps.verify_checkpoints.outputs.checkpoints_image }}
 
     steps:
-      - name: Install skopeo
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y skopeo
-
       - name: Copy checkpoint image to Docker Hub
         env:
           HARBOR_USERNAME: ${{ secrets.HARBOR_USERNAME }}
@@ -68,11 +64,20 @@ jobs:
             exit 1
           fi
 
-          skopeo copy --preserve-digests \
-            --src-creds "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
-            --dest-creds "${DOCKERHUB_USERNAME}:${DOCKERHUB_TOKEN}" \
-            "docker://${CHECKPOINTS_SOURCE_IMAGE}" \
-            "docker://${CHECKPOINTS_DOCKERHUB_IMAGE}"
+          docker run --rm \
+            --entrypoint /bin/sh \
+            -e CHECKPOINTS_SOURCE_IMAGE \
+            -e CHECKPOINTS_DOCKERHUB_IMAGE \
+            -e HARBOR_USERNAME \
+            -e HARBOR_PASSWORD \
+            -e DOCKERHUB_USERNAME \
+            -e DOCKERHUB_TOKEN \
+            "${SKOPEO_IMAGE}" \
+            -ceu 'skopeo copy --preserve-digests \
+              --src-creds "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+              --dest-creds "${DOCKERHUB_USERNAME}:${DOCKERHUB_TOKEN}" \
+              "docker://${CHECKPOINTS_SOURCE_IMAGE}" \
+              "docker://${CHECKPOINTS_DOCKERHUB_IMAGE}"'
 
       - name: Verify Docker Hub checkpoint digest
         id: verify_checkpoints
@@ -81,10 +86,16 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           expected_digest="${CHECKPOINTS_SOURCE_IMAGE##*@}"
-          actual_digest="$(skopeo inspect \
-            --creds "${DOCKERHUB_USERNAME}:${DOCKERHUB_TOKEN}" \
-            --format '{{.Digest}}' \
-            "docker://${CHECKPOINTS_DOCKERHUB_IMAGE}")"
+          actual_digest="$(docker run --rm \
+            --entrypoint /bin/sh \
+            -e CHECKPOINTS_DOCKERHUB_IMAGE \
+            -e DOCKERHUB_USERNAME \
+            -e DOCKERHUB_TOKEN \
+            "${SKOPEO_IMAGE}" \
+            -ceu 'skopeo inspect \
+              --creds "${DOCKERHUB_USERNAME}:${DOCKERHUB_TOKEN}" \
+              --format "{{.Digest}}" \
+              "docker://${CHECKPOINTS_DOCKERHUB_IMAGE}"')"
 
           if [ "${actual_digest}" != "${expected_digest}" ]; then
             echo "Docker Hub checkpoint digest mismatch: expected ${expected_digest}, got ${actual_digest}"
@@ -97,7 +108,7 @@ jobs:
 
   public:
     name: Public pixi-with-checkpoints image
-    runs-on: ubuntu-latest
+    runs-on: astera-sh-builder
     needs: sync_checkpoints
     permissions:
       contents: read
@@ -105,16 +116,6 @@ jobs:
       image-ref: ${{ steps.public-ref.outputs.image }}
 
     steps:
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
-
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -179,22 +180,12 @@ jobs:
 
   astera:
     name: Astera EXT image
-    runs-on: ubuntu-latest
+    runs-on: astera-sh-builder
     needs: public
     permissions:
       contents: read
 
     steps:
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
-
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## Summary
- run Docker publish jobs on the Astera builder runner so Harbor access stays behind the VPN
- use a pinned skopeo container instead of apt-installing skopeo on the runner
- remove GitHub-hosted runner disk cleanup steps from self-hosted jobs

## Validation
- mirrored checkpoint image locally and verified Docker Hub digest matches sha256:ff1dd2b42c3afd593e034cf81df1bf1862c27ae491f46cc10e105629f1102781
- git diff --check
- parsed .github/workflows/docker.yml with Ruby YAML loader
- tested the pinned skopeo inspect command locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image building workflow with infrastructure improvements to enhance build efficiency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->