### PR TITLE
test(runs): isolate runner tests from ACTL env

### DIFF
--- a/tests/runs/conftest.py
+++ b/tests/runs/conftest.py
@@ -3,15 +3,22 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
+from sampleworks.runs import runner
 
 
 @pytest.fixture(autouse=True)
-def force_pixi_argv(monkeypatch: pytest.MonkeyPatch) -> None:
+def force_pixi_argv(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Keep argv assertions deterministic across dev and ACTL image environments."""
     monkeypatch.delenv("SAMPLEWORKS_GRID_SEARCH_SCRIPT", raising=False)
     monkeypatch.delenv("SAMPLEWORKS_PIXI_PROJECT_DIR", raising=False)
+    monkeypatch.setattr(
+        runner,
+        "WORKSPACE_GRID_SEARCH_SCRIPT",
+        str(tmp_path / "missing-workspace" / "run_grid_search.py"),
+    )
     for var in (
         "RUNTIME_PIXI",
         "SAMPLEWORKS_ALLOW_RUNTIME_PIXI",

--- a/tests/runs/conftest.py
+++ b/tests/runs/conftest.py
@@ -9,9 +9,16 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def force_pixi_argv(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep argv assertions deterministic on machines with /app/.pixi present."""
+    """Keep argv assertions deterministic across dev and ACTL image environments."""
     monkeypatch.delenv("SAMPLEWORKS_GRID_SEARCH_SCRIPT", raising=False)
     monkeypatch.delenv("SAMPLEWORKS_PIXI_PROJECT_DIR", raising=False)
+    for var in (
+        "RUNTIME_PIXI",
+        "SAMPLEWORKS_ALLOW_RUNTIME_PIXI",
+        "SAMPLEWORKS_REQUIRE_PREBUILT_PIXI",
+        "SAMPLEWORKS_SKIP_ENV_PREPARE",
+    ):
+        monkeypatch.delenv(var, raising=False)
     for var in list(os.environ):
         if var.startswith("SAMPLEWORKS_") and var.endswith("_PYTHON"):
             monkeypatch.delenv(var, raising=False)

--- a/tests/runs/test_runner.py
+++ b/tests/runs/test_runner.py
@@ -348,6 +348,7 @@ def test_pre_jobs_run_before_main_jobs(tmp_path: Path, monkeypatch: pytest.Monke
     """Sequential pre-jobs complete before regular jobs are launched."""
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("SAMPLEWORKS_PIXI_PROJECT_DIR", str(tmp_path))
+    monkeypatch.delenv("SAMPLEWORKS_FORCE_PIXI", raising=False)
     monkeypatch.setenv("SAMPLEWORKS_ANALYSIS_PYTHON", sys.executable)
     pre_script = tmp_path / "pre.py"
     main_script = tmp_path / "main.py"


### PR DESCRIPTION
## Summary

- clear inherited ACTL/runtime pixi policy env vars in runner test fixture
- keep runner argv tests deterministic with SAMPLEWORKS_FORCE_PIXI only
## Summary by CodeRabbit

* **Tests**
  * Enhanced environment cleanup in test fixtures to ensure more deterministic and reliable test assertions across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->