### PR TITLE
fix(docker): set sampleworks workspace home

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,8 @@ RUN rm -rf /app/src /app/scripts /app/experiments /app/analyses \
     && mkdir -p /home/dev/workspace
 
 COPY --chmod=755 run_experiments run_experiments.sh run_all_models.sh run_analysis run_analysis.sh /usr/local/bin/
-RUN printf '\n# ACTL scientist workflow: land in the synced Sampleworks checkout.\nif [[ $- == *i* ]] && [ -z "${SAMPLEWORKS_NO_AUTO_CD:-}" ] && [ -d /home/dev/workspace ]; then\n    cd /home/dev/workspace\nfi\n' >> /root/.bashrc
+RUN printf '\n# ACTL scientist workflow: land in the synced Sampleworks checkout.\nif [[ $- == *i* ]] && [ -z "${SAMPLEWORKS_NO_AUTO_CD:-}" ] && [ -d /home/dev/workspace ]; then\n    cd /home/dev/workspace\nfi\n' \
+    | tee -a /root/.bashrc /home/dev/.bashrc >/dev/null
 
 # ============================================================================
 # Public runtime: regular Sampleworks image for the public registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,16 @@ ENV BOLTZ1_CHECKPOINT=/checkpoints/boltz1_conf.ckpt \
     BOLTZ2_CHECKPOINT=/checkpoints/boltz2_conf.ckpt \
     CCD_PATH=/checkpoints/ccd.pkl \
     RF3_CHECKPOINT=/checkpoints/rf3_foundry_01_24_latest.ckpt \
-    PROTENIX_CHECKPOINT=/checkpoints/protenix_base_default_v0.5.0.pt
+    PROTENIX_CHECKPOINT=/checkpoints/protenix_base_default_v0.5.0.pt \
+    HOME=/home/dev \
+    XDG_CONFIG_HOME=/home/dev/.config \
+    XDG_CACHE_HOME=/home/dev/.cache \
+    XDG_DATA_HOME=/home/dev/.local/share \
+    SHELL=/bin/bash
+
+RUN mkdir -p /home/dev/.config /home/dev/.cache /home/dev/.local/share /home/dev/workspace
+
+WORKDIR /home/dev
 
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["--help"]

--- a/Dockerfile.astera
+++ b/Dockerfile.astera
@@ -45,6 +45,8 @@ COPY --from=ext-cli /ext /usr/local/bin/ext
 
 RUN chmod 0755 /usr/local/bin/ext
 
+WORKDIR /home/dev
+
 # ACTL workspace pods intentionally keep the inherited root runtime user: the
 # prebuilt /app/.pixi environments and shared PVC workflows are currently
 # root-oriented, and switching USER here would break existing scientist runs.

--- a/tests/runs/conftest.py
+++ b/tests/runs/conftest.py
@@ -3,15 +3,29 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
+from sampleworks.runs import runner
 
 
 @pytest.fixture(autouse=True)
-def force_pixi_argv(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep argv assertions deterministic on machines with /app/.pixi present."""
+def force_pixi_argv(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep argv assertions deterministic across dev and ACTL image environments."""
     monkeypatch.delenv("SAMPLEWORKS_GRID_SEARCH_SCRIPT", raising=False)
     monkeypatch.delenv("SAMPLEWORKS_PIXI_PROJECT_DIR", raising=False)
+    monkeypatch.setattr(
+        runner,
+        "WORKSPACE_GRID_SEARCH_SCRIPT",
+        str(tmp_path / "missing-workspace" / "run_grid_search.py"),
+    )
+    for var in (
+        "RUNTIME_PIXI",
+        "SAMPLEWORKS_ALLOW_RUNTIME_PIXI",
+        "SAMPLEWORKS_REQUIRE_PREBUILT_PIXI",
+        "SAMPLEWORKS_SKIP_ENV_PREPARE",
+    ):
+        monkeypatch.delenv(var, raising=False)
     for var in list(os.environ):
         if var.startswith("SAMPLEWORKS_") and var.endswith("_PYTHON"):
             monkeypatch.delenv(var, raising=False)


### PR DESCRIPTION
## Summary\n- set HOME/XDG/SHELL in the public Sampleworks runtime image\n- create /home/dev state directories and make /home/dev the image WORKDIR\n- explicitly keep the Astera overlay WORKDIR aligned with ACTL workspace images\n\n## Testing\n- Not run locally: Docker image build requires checkpoint/image inputs not available in this environment.\n\n## Acceptance notes\n- After publish, verify `actl pod up --image sampleworks` reports `pwd=/home/dev` and `HOME=/home/dev`.\n- Once the image ships, the temporary `homePath: /home/dev` catalog override can be dropped from asteractl.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container runtime environment to establish a dedicated user workspace, set standardized shell and XDG home paths, and ensure the workspace is used as the default working directory; startup shell initialization now applies to both root and the dev user.

* **Tests**
  * Improved test reliability by making environment handling deterministic across runs, expanding environment-variable cleanup, and isolating runtime script references to a temporary workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->