### PR TITLE
chore(docker): install ACTL shell and debug tools

### DIFF
--- a/Dockerfile.astera
+++ b/Dockerfile.astera
@@ -34,12 +34,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         nano \
         rsync \
         vim \
+        zsh \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean \
     && mkdir -p /home/dev/.config /home/dev/.cache /home/dev/.local/share /home/dev/workspace \
     && install -m 0755 /app/run_experiments /usr/local/bin/run_experiments \
     && install -m 0755 /app/run_experiments.sh /usr/local/bin/run_experiments.sh \
-    && install -m 0755 /app/run_all_models.sh /usr/local/bin/run_all_models.sh
+    && install -m 0755 /app/run_all_models.sh /usr/local/bin/run_all_models.sh \
+    && for cmd in emacs zsh; do command -v "${cmd}"; done
 
 COPY --from=ext-cli /ext /usr/local/bin/ext
 

--- a/Dockerfile.astera
+++ b/Dockerfile.astera
@@ -30,10 +30,21 @@ ENV DEBIAN_FRONTEND=noninteractive \
     SAMPLEWORKS_SKIP_ENV_PREPARE=1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        dnsutils \
         emacs-nox \
+        git \
+        htop \
+        iputils-ping \
         nano \
+        ncdu \
         rsync \
+        tini \
+        tmux \
         vim \
+        wget \
         zsh \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean \
@@ -41,7 +52,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && install -m 0755 /app/run_experiments /usr/local/bin/run_experiments \
     && install -m 0755 /app/run_experiments.sh /usr/local/bin/run_experiments.sh \
     && install -m 0755 /app/run_all_models.sh /usr/local/bin/run_all_models.sh \
-    && for cmd in emacs zsh; do command -v "${cmd}" >/dev/null 2>&1 || exit 1; done
+    && for cmd in \
+        bash curl dig emacs git htop nano ncdu ping rsync tini tmux vim wget zsh; do \
+          command -v "${cmd}" >/dev/null 2>&1 || exit 1; \
+        done
 
 COPY --from=ext-cli /ext /usr/local/bin/ext
 

--- a/Dockerfile.astera
+++ b/Dockerfile.astera
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && install -m 0755 /app/run_experiments /usr/local/bin/run_experiments \
     && install -m 0755 /app/run_experiments.sh /usr/local/bin/run_experiments.sh \
     && install -m 0755 /app/run_all_models.sh /usr/local/bin/run_all_models.sh \
-    && for cmd in emacs zsh; do command -v "${cmd}"; done
+    && for cmd in emacs zsh; do command -v "${cmd}" >/dev/null 2>&1 || exit 1; done
 
 COPY --from=ext-cli /ext /usr/local/bin/ext
 


### PR DESCRIPTION
## Summary
- add the shared ACTL shell/network/debug tooling to the Astera Sampleworks overlay image
- install curl, wget, htop, tmux, ncdu, ping, dig, tini, git, and base shell/cert packages alongside the existing editors/zsh
- expand the build-time command check to fail fast if any expected tool is missing

## Validation
- git diff --check

## Related
- Catalog/image rollup: Astera-org/asteractl#74
