### PR TITLE
feat(eval): canonicalize mixed-altloc modified residues

### DIFF
--- a/src/sampleworks/eval/structure_utils.py
+++ b/src/sampleworks/eval/structure_utils.py
@@ -16,7 +16,7 @@ from loguru import logger
 from sampleworks.core.rewards.protocol import RewardInputs
 from sampleworks.eval.eval_dataclasses import ProteinConfig
 from sampleworks.models.protocol import GenerativeModelInput
-from sampleworks.utils.atom_array_utils import load_structure_with_altlocs
+from sampleworks.utils.atom_array_utils import BLANK_ALTLOC_IDS, load_structure_with_altlocs
 from sampleworks.utils.atom_reconciler import AtomReconciler
 from sampleworks.utils.framework_utils import match_batch
 
@@ -477,47 +477,118 @@ def _closest_canonical_amino_acid(res_name: str) -> str | None:
 def canonicalize_mixed_altloc_residues(
     atom_array: AtomArray | AtomArrayStack,
 ) -> AtomArray | AtomArrayStack:
-    """Rename modified amino acids that share a residue position with a canonical residue.
+    """Canonicalize residue positions whose altlocs disagree on ``res_name``.
 
-    At residue positions whose altlocs disagree on ``res_name``, such as a
-    canonical amino acid with compositional heterogeneity as a modified form (e.g. CYS with an
-    alternate CSO), we rename the modified records to their canonical
-    amino acid (via :func:`_closest_canonical_amino_acid`) and clear the ``hetero`` flag in the
-    biotite AtomArray annotation. The conformers then share ``res_name``/``hetero``, so
-    :func:`map_altlocs_to_stack` can stack them. Running ``filter_to_common_atoms`` afterwards
-    helps drop modified atoms such as the CSO hydroxyl oxygen.
+    Compositional heterogeneity, such as a canonical CYS with an alternate CSO at the same
+    position, makes :func:`map_altlocs_to_stack` fail: the conformers disagree on
+    ``res_name``/``hetero`` (so ``biotite.stack()`` rejects them) and the modified form carries
+    extra atoms that are incompatible with the canonical residue (e.g. the CSO sulfinate
+    oxygens). This function makes such positions stackable by
 
-    Positions with a single, consistent ``res_name`` are left untouched, so cases like a MSE with
-    no compositional heterogeneity are preserved.
+    1. renaming every residue at a mixed position to their shared canonical parent (via
+       :func:`_closest_canonical_amino_acid`) and clearing ``hetero``, but only when *all*
+       residue names at that position resolve to the *same* canonical parent, and
+    2. dropping atoms that are not shared by every altloc at a canonicalized position, so each
+       conformer ends with an identical atom set. The modified-only atoms are removed while both
+       altlocs' coordinates are preserved (the alternate geometry is kept for the ensemble).
+
+    Positions with a single, consistent ``res_name`` (e.g. an ordinary MSE with no
+    heterogeneity) are left untouched. Positions whose altlocs do *not* share a single canonical
+    parent (e.g. two different non-canonicals, or a canonical alongside a residue with no amino
+    acid parent) are also left untouched rather than partially renamed: renaming only the
+    residues that happen to map somewhere would still leave the position stacking-incompatible,
+    so this logs a warning and defers the position to downstream handling instead.
+
+    Notes
+    -----
+    Step 2 requires ``altloc_id`` (present on structures loaded via
+    :func:`~sampleworks.utils.atom_array_utils.load_structure_with_altlocs`). It does not cover
+    the case where atomworks parses the modified form as a *separate* residue under a shifted
+    ``res_id`` rather than an altloc. That path still needs the CIF-level
+    :func:`~sampleworks.utils.cif_utils.resolve_mixed_hetatm_atom_altlocs`.
+
+    That CIF-level function is not simply reused here because has a different tolerance for losing
+    the modified conformer: it prepares a *single* structure to feed a ModelWrapper, where
+    atomworks would otherwise insert a spurious extra residue, so it deliberately drops the
+    modified altloc and keeps only the canonical one. This function instead prepares an evaluation
+    *reference ensemble*, where both conformers are real experimental data that must be preserved
+    as separate stack members. Unifying the two would need a shared "detect mixed compositional
+    heterogeneity" core with the two resolution policies (drop-modified vs. keep-both-canonicalized)
+    layered on top as options.
 
     Parameters
     ----------
     atom_array : AtomArray | AtomArrayStack
-        Reference structure loaded with altlocs
+        Reference structure loaded with altlocs.
 
     Returns
     -------
     AtomArray | AtomArrayStack
-        Copy of the input with mixed-altloc modified residues renamed to their closest canonical.
+        Copy of the input with mixed-altloc modified residues canonicalized.
     """
     out = atom_array.copy()
-    res_names = out.res_name.tolist()
-    ins_codes = getattr(out, "ins_code", np.full(out.array_length(), "")).tolist()
+    n_atoms = out.array_length()
+    ins_codes = getattr(out, "ins_code", np.full(n_atoms, "")).tolist()
     positions = list(zip(out.chain_id.tolist(), out.res_id.tolist(), ins_codes))
 
     res_names_by_position: dict[tuple, set[str]] = defaultdict(set)
-    for position, res_name in zip(positions, res_names):
+    for position, res_name in zip(positions, out.res_name.tolist()):
         res_names_by_position[position].add(res_name)
+    mixed_positions = {pos for pos, names in res_names_by_position.items() if len(names) > 1}
 
+    # 1. Only canonicalize positions whose altlocs all resolve to the same canonical parent. A
+    #    partial rename that still leaves mismatched res_names at the position wouldn't be
+    #    stackable anyway, so it's better to leave those untouched and warn.
     parent_cache: dict[str, str | None] = {}
-    for i, (position, res_name) in enumerate(zip(positions, res_names)):
-        if len(res_names_by_position[position]) == 1:
-            continue  # single consistent res_name means it doesn't have comp het
-        parent = parent_cache.setdefault(res_name, _closest_canonical_amino_acid(res_name))
-        if parent is not None and parent != res_name:
+    canonical_parent_by_position: dict[tuple, str] = {}
+    for position in mixed_positions:
+        parents = {
+            parent_cache.setdefault(name, _closest_canonical_amino_acid(name))
+            for name in res_names_by_position[position]
+        }
+        if len(parents) == 1 and (parent := parents.pop()) is not None:
+            canonical_parent_by_position[position] = parent
+        else:
+            logger.warning(
+                f"Position {position} has altlocs that do not share a canonical parent "
+                f"({sorted(res_names_by_position[position])}). Leaving it for downstream handling."
+            )
+
+    for i, position in enumerate(positions):
+        parent = canonical_parent_by_position.get(position)
+        if parent is not None:
             out.res_name[i] = parent
             out.hetero[i] = False
-    return out
+
+    # 2. Drop atoms not shared by every altloc at a canonicalized position (e.g. the modified
+    #    form's extra atoms), so each conformer has an identical, stackable atom set.
+    altloc_ids = getattr(out, "altloc_id", None)
+    if altloc_ids is None or not canonical_parent_by_position:
+        return out
+
+    atom_names = out.atom_name.tolist()
+    altlocs = altloc_ids.tolist()
+    indices_by_position: dict[tuple, list[int]] = defaultdict(list)
+    for i, position in enumerate(positions):
+        if position in canonical_parent_by_position:
+            indices_by_position[position].append(i)
+
+    keep = np.ones(n_atoms, dtype=bool)
+    for indices in indices_by_position.values():
+        names_by_altloc: dict[str, set[str]] = defaultdict(set)
+        for i in indices:
+            if altlocs[i] not in BLANK_ALTLOC_IDS:
+                names_by_altloc[altlocs[i]].add(atom_names[i])
+        if len(names_by_altloc) < 2:
+            continue  # need at least two conformers to know which atoms are shared
+        shared_names = set.intersection(*names_by_altloc.values())
+        for i in indices:
+            if altlocs[i] not in BLANK_ALTLOC_IDS and atom_names[i] not in shared_names:
+                keep[i] = False
+
+    if isinstance(out, AtomArrayStack):
+        return out[:, keep]
+    return out[keep]
 
 
 def get_reference_atomarraystack(

--- a/src/sampleworks/eval/structure_utils.py
+++ b/src/sampleworks/eval/structure_utils.py
@@ -1,5 +1,6 @@
 import re
 import traceback
+from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -8,6 +9,8 @@ from typing import Any, cast, overload
 import numpy as np
 import torch
 from atomworks.io.transforms.atom_array import ensure_atom_array_stack
+from atomworks.io.utils.ccd import ChainType, UNKNOWN_AA
+from atomworks.io.utils.sequence import get_1_from_3_letter_code, get_3_from_1_letter_code
 from biotite.structure import AtomArray, AtomArrayStack, from_template
 from loguru import logger
 from sampleworks.core.rewards.protocol import RewardInputs
@@ -448,6 +451,75 @@ def get_asym_unit_from_structure(
     return atom_array
 
 
+def _closest_canonical_amino_acid(res_name: str) -> str | None:
+    """Map a (possibly modified) residue name to its canonical parent amino acid.
+
+    Uses atomworks' mapping, e.g. ``CSO -> CYS``, ``MSE -> MET``. Standard amino
+    acids map to themselves and "residues" with no amino-acid (ligands, waters) return ``None``.
+
+    Parameters
+    ----------
+    res_name : str
+        Three letter amino acid name.
+
+    Returns
+    -------
+    str | None
+        Canonical three letter amino acid name, or ``None`` if HETATM.
+    """
+    one_letter = get_1_from_3_letter_code(
+        res_name, ChainType.POLYPEPTIDE_L, use_closest_canonical=True
+    )
+    parent = get_3_from_1_letter_code(one_letter, ChainType.POLYPEPTIDE_L)
+    return None if parent == UNKNOWN_AA else parent
+
+
+def canonicalize_mixed_altloc_residues(
+    atom_array: AtomArray | AtomArrayStack,
+) -> AtomArray | AtomArrayStack:
+    """Rename modified amino acids that share a residue position with a canonical residue.
+
+    At residue positions whose altlocs disagree on ``res_name``, such as a
+    canonical amino acid with compositional heterogeneity as a modified form (e.g. CYS with an
+    alternate CSO), we rename the modified records to their canonical
+    amino acid (via :func:`_closest_canonical_amino_acid`) and clear the ``hetero`` flag in the
+    biotite AtomArray annotation. The conformers then share ``res_name``/``hetero``, so
+    :func:`map_altlocs_to_stack` can stack them. Running ``filter_to_common_atoms`` afterwards
+    helps drop modified atoms such as the CSO hydroxyl oxygen.
+
+    Positions with a single, consistent ``res_name`` are left untouched, so cases like a MSE with
+    no compositional heterogeneity are preserved.
+
+    Parameters
+    ----------
+    atom_array : AtomArray | AtomArrayStack
+        Reference structure loaded with altlocs
+
+    Returns
+    -------
+    AtomArray | AtomArrayStack
+        Copy of the input with mixed-altloc modified residues renamed to their closest canonical.
+    """
+    out = atom_array.copy()
+    res_names = out.res_name.tolist()
+    ins_codes = getattr(out, "ins_code", np.full(out.array_length(), "")).tolist()
+    positions = list(zip(out.chain_id.tolist(), out.res_id.tolist(), ins_codes))
+
+    res_names_by_position: dict[tuple, set[str]] = defaultdict(set)
+    for position, res_name in zip(positions, res_names):
+        res_names_by_position[position].add(res_name)
+
+    parent_cache: dict[str, str | None] = {}
+    for i, (position, res_name) in enumerate(zip(positions, res_names)):
+        if len(res_names_by_position[position]) == 1:
+            continue  # single consistent res_name means it doesn't have comp het
+        parent = parent_cache.setdefault(res_name, _closest_canonical_amino_acid(res_name))
+        if parent is not None and parent != res_name:
+            out.res_name[i] = parent
+            out.hetero[i] = False
+    return out
+
+
 def get_reference_atomarraystack(
     protein_config: ProteinConfig, altloc_occupancies: dict[str, float]
 ) -> tuple[Path | str | None, AtomArrayStack | None]:
@@ -464,7 +536,12 @@ def get_reference_atomarraystack(
     ref_path = protein_config.get_reference_structure_path(altloc_occupancies)
     if ref_path is None:
         return None, None
-    ref_struct = load_structure_with_altlocs(ref_path)
+
+    # A modified residue (e.g. CSO) recorded as an altloc at the same position as its canonical
+    # form (e.g. CYS) makes map_altlocs_to_stack fail: the conformers disagree on res_name/hetero
+    # so biotite.stack() rejects them. Canonicalize these residues to get map_altlocs_to_stack to
+    # work
+    ref_struct = canonicalize_mixed_altloc_residues(load_structure_with_altlocs(ref_path))
     if ref_struct.coord is None:
         raise ValueError(f"Unable to load coordinates from {ref_path} Please check file")
     if isinstance(ref_struct, AtomArray):

--- a/src/sampleworks/eval/structure_utils.py
+++ b/src/sampleworks/eval/structure_utils.py
@@ -539,13 +539,9 @@ def canonicalize_mixed_altloc_residues(
     # 1. Only canonicalize positions whose altlocs all resolve to the same canonical parent. A
     #    partial rename that still leaves mismatched res_names at the position wouldn't be
     #    stackable anyway, so it's better to leave those untouched and warn.
-    parent_cache: dict[str, str | None] = {}
     canonical_parent_by_position: dict[tuple, str] = {}
     for position in mixed_positions:
-        parents = {
-            parent_cache.setdefault(name, _closest_canonical_amino_acid(name))
-            for name in res_names_by_position[position]
-        }
+        parents = {_closest_canonical_amino_acid(name) for name in res_names_by_position[position]}
         if len(parents) == 1 and (parent := parents.pop()) is not None:
             canonical_parent_by_position[position] = parent
         else:

--- a/tests/eval/test_structure_utils.py
+++ b/tests/eval/test_structure_utils.py
@@ -17,6 +17,7 @@ from sampleworks.eval.structure_utils import (
     get_reference_structure_coords,
     parse_selection_string,
 )
+from sampleworks.utils.atom_array_utils import map_altlocs_to_stack
 
 
 @pytest.fixture
@@ -291,6 +292,43 @@ class TestGetReferenceAtomArrayStack:
         assert struct is not None
         assert isinstance(struct, AtomArrayStack)
 
+    def test_6ni6_mixed_altloc_residue_stacks_cleanly(self, resources_dir):
+        """End-to-end regression for the 6NI6 CYS/CSO/CSO compositional heterogeneity.
+
+        Chain A residue 101 carries a canonical CYS (altloc A) alongside two CSO altlocs
+        (B, C) with an extra ``OD`` atom. This tests failure via
+        ``get_reference_atomarraystack`` -> ``map_altlocs_to_stack``.
+        """
+        config = ProteinConfig(
+            protein="6ni6",
+            base_map_dir=resources_dir / "6NI6",
+            selection=[
+                "chain A and resi 101",
+            ],
+            resolution=1.8,
+            map_pattern="{occ_str}.ccp4",
+            structure_pattern="6NI6_single_001_density_input.cif",
+        )
+
+        _, ref_struct = get_reference_atomarraystack(config, {"A": 0.5, "B": 0.25, "C": 0.25})
+        assert ref_struct is not None
+
+        stacked, _ = map_altlocs_to_stack(
+            ref_struct, selection="(chain_id == 'A') & (res_id == 101)", return_full_array=False
+        )
+        assert stacked.stack_depth() == 3  # altlocs A, B, C
+
+        res_names = cast(np.ndarray, stacked.res_name)
+        hetero = cast(np.ndarray, stacked.hetero)
+        atom_names = cast(np.ndarray, stacked.atom_name)
+        assert set(np.unique(res_names)) == {"CYS"}
+        assert not hetero.any()
+        assert "OD" not in atom_names  # CSO's incompatible extra atom is gone
+
+        for i in range(stacked.stack_depth()):
+            frame_atom_names = list(cast(np.ndarray, stacked[i].atom_name))
+            assert len(frame_atom_names) == len(set(frame_atom_names))  # unique atom identities
+
 
 class TestGetReferenceStructureCoords:
     """Tests for get_reference_structure_coords function."""
@@ -352,8 +390,14 @@ class TestCanonicalizeMixedAltlocResidues:
 
     @staticmethod
     def _mixed_array() -> AtomArray:
-        # (A,10): canonical CYS + modified CSO compositional heterogeneity
-        # (A,11): MSE only, single res_name, must be left untouched
+        """Build a minimal array with one mixed and one untouched position.
+
+        Returns
+        -------
+        AtomArray
+            ``(A, 10)`` holds a canonical CYS plus a modified CSO (compositional
+            heterogeneity); ``(A, 11)`` holds a lone MSE that must be left untouched.
+        """
         aa = AtomArray(3)
         aa.coord = np.zeros((3, 3), dtype=np.float32)
         aa.set_annotation("chain_id", np.array(["A", "A", "A"]))
@@ -363,14 +407,36 @@ class TestCanonicalizeMixedAltlocResidues:
         aa.set_annotation("atom_name", np.array(["CA", "CA", "CA"]))
         return aa
 
+    @staticmethod
+    def _mixed_array_with_altlocs() -> AtomArray:
+        """Build a mixed CYS/CSO position with per-altloc atoms and an extra CSO atom.
+
+        Returns
+        -------
+        AtomArray
+            ``(A, 10)`` as canonical CYS (altloc ``A``: ``CA``, ``SG``) alternating with a
+            modified CSO (altloc ``B``: ``CA``, ``SG`` and the incompatible extra ``OD``).
+        """
+        aa = AtomArray(5)
+        aa.coord = np.zeros((5, 3), dtype=np.float32)
+        aa.set_annotation("chain_id", np.array(["A", "A", "A", "A", "A"]))
+        aa.set_annotation("res_id", np.array([10, 10, 10, 10, 10]))
+        aa.set_annotation("res_name", np.array(["CYS", "CYS", "CSO", "CSO", "CSO"]))
+        aa.set_annotation("hetero", np.array([False, False, True, True, True]))
+        aa.set_annotation("atom_name", np.array(["CA", "SG", "CA", "SG", "OD"]))
+        aa.set_annotation("altloc_id", np.array(["A", "A", "B", "B", "B"]))
+        return aa
+
     @pytest.mark.parametrize(
         "res_name,expected",
         [("CSO", "CYS"), ("MSE", "MET"), ("ALA", "ALA"), ("HOH", None)],
     )
     def test_closest_canonical_amino_acid(self, res_name, expected):
+        """The modified-to-canonical mapping resolves PTMs and rejects non-amino-acids."""
         assert _closest_canonical_amino_acid(res_name) == expected
 
     def test_renames_modified_at_mixed_position(self):
+        """Modified records at a mixed position are renamed and de-heteroed; lone MSE is kept."""
         result = canonicalize_mixed_altloc_residues(self._mixed_array())
         res_name = cast(np.ndarray, result.res_name)
         hetero = cast(np.ndarray, result.hetero)
@@ -378,7 +444,51 @@ class TestCanonicalizeMixedAltlocResidues:
         assert not hetero[0] and not hetero[1]  # hetero cleared
         assert res_name[2] == "MSE" and hetero[2]  # MSE untouched
 
+    def test_drops_incompatible_modified_atoms(self):
+        """The modified form's extra atom is dropped so both altlocs share one atom set."""
+        result = canonicalize_mixed_altloc_residues(self._mixed_array_with_altlocs())
+        atom_name = cast(np.ndarray, result.atom_name)
+        altloc_id = cast(np.ndarray, result.altloc_id)
+        assert "OD" not in set(atom_name)  # incompatible extra removed
+        assert set(atom_name[altloc_id == "A"]) == set(atom_name[altloc_id == "B"])
+        assert set(cast(np.ndarray, result.res_name)) == {"CYS"}
+        assert not cast(np.ndarray, result.hetero).any()
+
+    def test_two_noncanonicals_no_canonical_warns(self, caplog):
+        """Two non-canonicals with no shared canonical parent are left untouched and logged."""
+        aa = AtomArray(2)
+        aa.coord = np.zeros((2, 3), dtype=np.float32)
+        aa.set_annotation("chain_id", np.array(["A", "A"]))
+        aa.set_annotation("res_id", np.array([20, 20]))
+        aa.set_annotation("res_name", np.array(["CSO", "SEP"]))
+        aa.set_annotation("hetero", np.array([True, True]))
+        aa.set_annotation("atom_name", np.array(["CA", "CA"]))
+        aa.set_annotation("altloc_id", np.array(["A", "B"]))
+        with caplog.at_level("WARNING"):
+            result = canonicalize_mixed_altloc_residues(aa)
+        # CSO -> CYS and SEP -> SER don't converge, so neither is renamed (a partial rename
+        # would still leave the position stacking-incompatible).
+        assert set(cast(np.ndarray, result.res_name)) == {"CSO", "SEP"}
+        assert cast(np.ndarray, result.hetero).all()
+        assert "canonical parent" in caplog.text
+
+    def test_partial_convergence_leaves_position_untouched(self, caplog):
+        """A canonical plus two non-convergent modified forms is left fully untouched."""
+        aa = AtomArray(3)
+        aa.coord = np.zeros((3, 3), dtype=np.float32)
+        aa.set_annotation("chain_id", np.array(["A", "A", "A"]))
+        aa.set_annotation("res_id", np.array([30, 30, 30]))
+        aa.set_annotation("res_name", np.array(["CYS", "CSO", "SEP"]))
+        aa.set_annotation("hetero", np.array([False, True, True]))
+        aa.set_annotation("atom_name", np.array(["CA", "CA", "CA"]))
+        aa.set_annotation("altloc_id", np.array(["A", "B", "C"]))
+        with caplog.at_level("WARNING"):
+            result = canonicalize_mixed_altloc_residues(aa)
+        assert list(cast(np.ndarray, result.res_name)) == ["CYS", "CSO", "SEP"]
+        assert "canonical parent" in caplog.text
+
     def test_does_not_mutate_input(self):
+        """Canonicalization operates on a copy and leaves the caller's array intact."""
         arr = self._mixed_array()
         canonicalize_mixed_altloc_residues(arr)
         assert cast(np.ndarray, arr.res_name)[1] == "CSO"

--- a/tests/eval/test_structure_utils.py
+++ b/tests/eval/test_structure_utils.py
@@ -8,7 +8,9 @@ import pytest
 from biotite.structure import AtomArray, AtomArrayStack
 from sampleworks.eval.eval_dataclasses import ProteinConfig
 from sampleworks.eval.structure_utils import (
+    _closest_canonical_amino_acid,
     apply_selection,
+    canonicalize_mixed_altloc_residues,
     extract_selection_coordinates,
     get_asym_unit_from_structure,
     get_reference_atomarraystack,
@@ -343,3 +345,40 @@ class TestGetReferenceStructureCoords:
         assert coords.ndim == 2
         assert coords.shape[1] == 3
         assert np.isfinite(coords).all()
+
+
+class TestCanonicalizeMixedAltlocResidues:
+    """Tests for canonicalize_mixed_altloc_residues / _closest_canonical_amino_acid."""
+
+    @staticmethod
+    def _mixed_array() -> AtomArray:
+        # (A,10): canonical CYS + modified CSO compositional heterogeneity
+        # (A,11): MSE only, single res_name, must be left untouched
+        aa = AtomArray(3)
+        aa.coord = np.zeros((3, 3), dtype=np.float32)
+        aa.set_annotation("chain_id", np.array(["A", "A", "A"]))
+        aa.set_annotation("res_id", np.array([10, 10, 11]))
+        aa.set_annotation("res_name", np.array(["CYS", "CSO", "MSE"]))
+        aa.set_annotation("hetero", np.array([False, True, True]))
+        aa.set_annotation("atom_name", np.array(["CA", "CA", "CA"]))
+        return aa
+
+    @pytest.mark.parametrize(
+        "res_name,expected",
+        [("CSO", "CYS"), ("MSE", "MET"), ("ALA", "ALA"), ("HOH", None)],
+    )
+    def test_closest_canonical_amino_acid(self, res_name, expected):
+        assert _closest_canonical_amino_acid(res_name) == expected
+
+    def test_renames_modified_at_mixed_position(self):
+        result = canonicalize_mixed_altloc_residues(self._mixed_array())
+        res_name = cast(np.ndarray, result.res_name)
+        hetero = cast(np.ndarray, result.hetero)
+        assert list(res_name[:2]) == ["CYS", "CYS"]  # CSO -> CYS
+        assert not hetero[0] and not hetero[1]  # hetero cleared
+        assert res_name[2] == "MSE" and hetero[2]  # MSE untouched
+
+    def test_does_not_mutate_input(self):
+        arr = self._mixed_array()
+        canonicalize_mixed_altloc_residues(arr)
+        assert cast(np.ndarray, arr.res_name)[1] == "CSO"


### PR DESCRIPTION
Adds a processing utility that is necessary for getting certain proteins (6NI6/6NI5) to work properly in the evaluation scripts, since those contain compositional heterogeneity in the form of a modified amino acid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added canonicalization for mixed alternate-location (altloc) residue names by mapping modified amino acids (e.g., CSO→CYS, MSE→MET) to canonical forms to improve altloc consistency.
  * Altloc reference loading now applies this canonicalization automatically.

* **Bug Fixes**
  * Improves stacking reliability by ensuring mixed-altloc residues converge to a shared compatible atom set and by clearing `hetero` for canonicalized residues.
  * When convergence isn’t possible, the residue is left unchanged and a warning is emitted.

* **Tests**
  * Added regression and unit tests covering canonicalization, atom dropping, warnings, and non-mutation of inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->