### PR TITLE
fix(protpardelle): complete denoising step wiring

### DIFF
--- a/.actlignore
+++ b/.actlignore
@@ -4,6 +4,8 @@
 grid_search_results/
 outputs/
 data/
+!/src/sampleworks/data/
+!/src/sampleworks/data/**
 initial_dataset_40*/
 checkpoints/
 release_data/

--- a/src/sampleworks/core/samplers/edm.py
+++ b/src/sampleworks/core/samplers/edm.py
@@ -415,17 +415,15 @@ class AF3EDMSampler:
 
         # Store eps separately for proper frame transformation
         # eps_scale will be float if check_context didn't raise
-        eps = torch.randn_like(maybe_augmented_state) * eps_scale  # ty: ignore[unsupported-operator]
+        eps = torch.randn_like(maybe_augmented_state) * eps_scale
         noisy_state = maybe_augmented_state + eps
         noisy_state = torch.as_tensor(noisy_state).detach().requires_grad_(allow_gradients)
 
         # t_hat will be float if check_context didn't raise
         # Use no_grad when gradients aren't needed to avoid memory overhead from
         # gradient checkpointing holding intermediate activations
-        # TODO testing adding eps to signature for use with Protpardelle-1c, if successful,
-        #   I need to modify the Protocol itself.
         with torch.set_grad_enabled(allow_gradients):
-            x_hat_0 = model_wrapper.step(noisy_state, t_hat, eps, features=features)
+            x_hat_0 = model_wrapper.step(noisy_state, t_hat, features=features)
 
         reconciler = (
             context.reconciler.to(torch.as_tensor(x_hat_0).device)

--- a/src/sampleworks/models/protpardelle/wrapper.py
+++ b/src/sampleworks/models/protpardelle/wrapper.py
@@ -14,10 +14,12 @@ forward pass), this is a ``StructureModelWrapper`` rather than a
 ``FlowModelWrapper``.
 """
 
+from __future__ import annotations
+
 import copy
 from dataclasses import dataclass, field
-from pathlib import Path
 from importlib.resources import files
+from pathlib import Path
 from typing import Any
 
 import biotite.structure as struc
@@ -45,6 +47,10 @@ ATOM37_NUM_ATOMS = residue_constants.atom_type_num
 # Number of aatype tokens for the 21-token alphabet (20 canonical + X).
 # Matches ``data.n_aatype_tokens`` in the Protpardelle-1c configs (e.g. cc89.yaml).
 NUM_AATYPE_TOKENS = 21
+
+# Atomworks keeps selenomethionine atoms as ``SE`` while Protpardelle's atom37
+# representation uses the canonical methionine sulfur slot, ``SD``.
+ATOM37_ATOM_NAME_ALIASES = {"SE": "SD"}
 
 # get default model configurations from protpardelle-1c/cc89
 sampling_partial_diffusion_all_atom = files("protpardelle").joinpath(
@@ -103,23 +109,28 @@ class ProtpardelleConditioning:
     residue_index: Float[Tensor, "batch L"]
     chain_index: Float[Tensor, "batch L"]
     atom_mask: Float[Tensor, "batch L 37"]
-    atom37_residue_index: Int[Tensor, "atoms"]
-    atom37_atom_index: Int[Tensor, "atoms"]
+    atom37_residue_index: Tensor
+    atom37_atom_index: Tensor
     sampling_kwargs: dict[str, Any]
     sequences: tuple[str, ...]
     x_self_conditioning: Float[Tensor, "batch L 37"] | None = None
+    _initialized: bool = field(default=False, init=False, repr=False)
 
     _FROZEN = frozenset(
         {"aatype", "seq_mask", "residue_index", "chain_index",
          "atom_mask", "sampling_kwargs", "sequences"}
     )
 
+    def __post_init__(self) -> None:
+        """Mark construction complete so selected conditioning fields become immutable."""
+        object.__setattr__(self, "_initialized", True)
+
     def __setattr__(self, key, value):
-        if key in self._FROZEN:
+        if key in self._FROZEN and getattr(self, "_initialized", False):
             raise AttributeError(
                 f"Cannot set attribute {key!r} on {self.__class__.__name__}, it is frozen!"
             )
-        super().__setattr__(key, value)
+        object.__setattr__(self, key, value)
 
 
 
@@ -362,18 +373,17 @@ class ProtpardelleWrapper:
 
         # Lay out chains exactly as Protpardelle's own sampling helper does so
         # residue/chain indexing (including inter-chain gaps) matches training.
-        prot_lens_per_chain = torch.tensor(
-            [[len(seq) for seq in sequences]], dtype=torch.long, device=self.device
-        )
+        # Keep the length tensor on CPU because Protpardelle's helper constructs
+        # intermediate residue indices on CPU before moving its outputs to the
+        # model device.
+        prot_lens_per_chain = torch.tensor([[len(seq) for seq in sequences]], dtype=torch.long)
         seq_mask, residue_index, chain_index = self.model.make_seq_mask_for_sampling(
             prot_lens_per_chain=prot_lens_per_chain
         )
 
         # Concatenate per-chain aatypes in chain order; chains are placed
         # contiguously at the front of the padded sequence by the helper above.
-        chain_aatypes = [
-            seq_to_aatype(seq, num_tokens=NUM_AATYPE_TOKENS) for seq in sequences  # ty: ignore
-        ]
+        chain_aatypes = [seq_to_aatype(seq, num_tokens=NUM_AATYPE_TOKENS) for seq in sequences]
         flat_aatype = torch.cat(chain_aatypes).to(self.device)
         padded_len = seq_mask.shape[1]
         aatype = torch.zeros((1, padded_len), dtype=torch.long, device=self.device)
@@ -413,7 +423,7 @@ class ProtpardelleWrapper:
             atom37_atom_index=atom37_atom_index,
             sampling_kwargs=sampling_kwargs,
             sequences=tuple(sequences),
-            x_self_conditioning=None
+            x_self_conditioning=None,
         )
 
         # x_init is a shape-compatible reference drawn from a Gaussian prior.
@@ -427,7 +437,7 @@ class ProtpardelleWrapper:
 
     def _atom37_indices_from_atom_array(
         self, atom_array
-    ) -> tuple[Int[Tensor, "atoms"], Int[Tensor, "atoms"]]:
+    ) -> tuple[Tensor, Tensor]:
         """Derive per-atom atom37 destination indices from an Atomworks atom array.
 
         For each atom in ``atom_array`` (the order the sampler's flat ``x_t``
@@ -455,8 +465,11 @@ class ProtpardelleWrapper:
             break the one-to-one correspondence with ``x_t``.
         """
         atom_names = np.asarray(atom_array.atom_name)
+        atom37_names = np.asarray(
+            [ATOM37_ATOM_NAME_ALIASES.get(str(name), str(name)) for name in atom_names]
+        )
 
-        unknown = sorted(set(atom_names) - set(residue_constants.atom_order))
+        unknown = sorted(set(atom37_names) - set(residue_constants.atom_order))
         if unknown:
             raise ValueError(
                 "asym_unit contains atom names not present in the atom37 "
@@ -465,7 +478,7 @@ class ProtpardelleWrapper:
             )
 
         atom_slots = np.array(
-            [residue_constants.atom_order[name] for name in atom_names], dtype=np.int64
+            [residue_constants.atom_order[name] for name in atom37_names], dtype=np.int64
         )
 
         # Contiguous residue ordinal (0..L-1) per atom, in atom order across chains.
@@ -572,11 +585,55 @@ class ProtpardelleWrapper:
         sampling_kwargs.update(config.extra_sampling_kwargs)
         return sampling_kwargs
 
+    def _expand_noise_level(
+        self,
+        t: Float[Tensor, "*batch"] | float,
+        conditioning: ProtpardelleConditioning,
+        dtype: torch.dtype,
+    ) -> Float[Tensor, "batch L"]:
+        """Convert a sampler timestep/noise scalar to Protpardelle's ``B x L`` tensor.
+
+        Parameters
+        ----------
+        t : Float[Tensor, "*batch"] | float
+            Sampler noise level for the current EDM step. May be a scalar or one
+            value per ensemble member.
+        conditioning : ProtpardelleConditioning
+            Conditioning whose sequence mask defines the batch and padded length.
+        dtype : torch.dtype
+            Floating dtype to use for the model call.
+
+        Returns
+        -------
+        Float[Tensor, "batch L"]
+            Noise level broadcast across valid/padded sequence positions on the
+            wrapper device.
+        """
+        seq_mask = conditioning.seq_mask.to(device=self.device, dtype=dtype)
+        noise_level = torch.as_tensor(t, device=self.device, dtype=dtype)
+
+        if noise_level.ndim == 0:
+            return noise_level.expand_as(seq_mask).clone()
+
+        if noise_level.ndim == 1:
+            if noise_level.shape[0] != seq_mask.shape[0]:
+                raise ValueError(
+                    f"Noise level batch size {noise_level.shape[0]} does not match "
+                    f"conditioning batch size {seq_mask.shape[0]}."
+                )
+            return noise_level[:, None].expand_as(seq_mask).clone()
+
+        if noise_level.shape != seq_mask.shape:
+            raise ValueError(
+                f"Noise level shape {tuple(noise_level.shape)} must be scalar, "
+                f"batch-sized, or match seq_mask shape {tuple(seq_mask.shape)}."
+            )
+        return noise_level
+
     def step(
         self,
         x_t: Float[Tensor, "batch atoms 3"],
         t: Float[Tensor, "*batch"] | float,
-        sigma_float: float,
         *,
         features: GenerativeModelInput[ProtpardelleConditioning] | None = None,
     ) -> Float[Tensor, "batch atoms 3"]:
@@ -594,7 +651,7 @@ class ProtpardelleWrapper:
         x_t : Float[Tensor, "batch atoms 3"]
             Noisy structure at timestep :math:`t`.
         t : Float[Tensor, "*batch"] | float
-            Current timestep/noise level (:math:`\hat{t}` from EDM schedule).
+            Current timestep/noise level (:math:`\\hat{t}` from EDM schedule).
         features : GenerativeModelInput[BoltzConditioning] | None
             Model features as returned by ``featurize``.
 
@@ -608,12 +665,20 @@ class ProtpardelleWrapper:
             raise ValueError("features with conditioning required for step()")
 
         cond = features.conditioning
+        x_t = x_t.to(device=self.device)
 
         # Our x_t is B x N x 3 (N = number of atoms); Protpardelle expects
         # B x L x 37 x 3. Scatter into the atom37 layout (gradient-preserving).
         x_t_atom37 = self._convert_to_atom37(cond, x_t)
 
-        noise_level = torch.full((cond.seq_mask.shape[0],), sigma_float, device=self.device)
+        noise_level = self._expand_noise_level(t, cond, x_t_atom37.dtype)
+
+        seq_mask = cond.seq_mask.to(device=self.device, dtype=x_t_atom37.dtype)
+        residue_index = cond.residue_index.to(device=self.device)
+        chain_index = cond.chain_index.to(device=self.device)
+        struct_self_cond = cond.x_self_conditioning
+        if struct_self_cond is not None:
+            struct_self_cond = struct_self_cond.to(device=self.device, dtype=x_t_atom37.dtype)
 
         # To understand all these arguments better, you can study the (complicated)
         # Protpardelle.sample method. Hints: partial diffusion is enabled and cc.enabled = False!
@@ -622,12 +687,12 @@ class ProtpardelleWrapper:
         x0, s_logprobs, x_self_cond, s_self_cond = self.model.forward(
             noisy_coords=x_t_atom37,
             noise_level=noise_level,
-            seq_mask=cond.seq_mask,
-            residue_index=cond.residue_index,
-            chain_index=cond.chain_index,
+            seq_mask=seq_mask,
+            residue_index=residue_index,
+            chain_index=chain_index,
             hotspot_mask=None,  # we don't support this yet
             struct_self_cond=(
-                features.conditioning.x_self_conditioning
+                struct_self_cond
                 if self.model.config.train.self_cond_train_prob > 0.5  # true for cc89
                 else None
             ),
@@ -646,7 +711,7 @@ class ProtpardelleWrapper:
         # ai-allatom sampling, so select the correct atoms via the atom37 mask.
         # The mask is identical across the batch (single input sequence), so a
         # single 2-D mask flattens every ensemble member consistently.
-        atom_mask_2d = cond.atom_mask[0].bool()  # [L, 37]
+        atom_mask_2d = cond.atom_mask[0].to(device=x0.device).bool()  # [L, 37]
         flat_coords = x0[:, atom_mask_2d]  # [batch, atoms, 3]
 
         return flat_coords.float()

--- a/tests/models/protpardelle/test_protpardelle_wrapper.py
+++ b/tests/models/protpardelle/test_protpardelle_wrapper.py
@@ -164,7 +164,7 @@ class TestConstructorValidation:
     def test_requires_checkpoint_and_config_paths(self):
         # checkpoint_path, config_path and device are required positional args.
         with pytest.raises(TypeError, match="required positional argument"):
-            ProtpardelleWrapper()
+            ProtpardelleWrapper()  # ty: ignore[missing-argument]
 
 
 class TestProtocolConformance:
@@ -229,6 +229,17 @@ class TestFeaturize:
         # Slots are valid atom37 indices; residues stay within L.
         assert int(cond.atom37_atom_index.max()) < 37
         assert int(cond.atom37_residue_index.max()) == len(SEQ_A) - 1
+
+    def test_mse_selenium_maps_to_methionine_sd(self, protpardelle_wrapper):
+        structure = _protein_structure("M")
+        atom_array = structure["asym_unit"]
+        selenium_mask = atom_array.atom_name == "SD"
+        atom_array.atom_name[selenium_mask] = "SE"
+
+        cond = protpardelle_wrapper.featurize(structure).conditioning
+        selenium_index = int(np.flatnonzero(selenium_mask)[0])
+
+        assert cond.atom37_atom_index[selenium_index].item() == residue_constants.atom_order["SD"]
 
     def test_featurize_requires_asym_unit(self, protpardelle_wrapper):
         structure = _protein_structure(SEQ_A)
@@ -314,10 +325,6 @@ class TestStep:
         with pytest.raises(ValueError, match="features"):
             protpardelle_wrapper.step(torch.zeros(1, 1, 3), 0.0)
 
-    @pytest.mark.skip(
-        reason="step() is intentionally incomplete (noise level / conditioning "
-        "wiring still TODO); only _convert_to_atom37 is implemented so far."
-    )
     @pytest.mark.slow
     def test_step_returns_coords(self, protpardelle_wrapper):
         short_seq = "ACDEFG"
@@ -325,7 +332,7 @@ class TestStep:
             _protein_structure(short_seq), ensemble_size=1, num_steps=3, s_churn=0.0
         )
         features = protpardelle_wrapper.featurize(structure)
-        result = protpardelle_wrapper.step(features)
+        result = protpardelle_wrapper.step(features.x_init, 1.0, features=features)
         assert torch.is_tensor(result)
         assert result.shape == features.x_init.shape
         assert result.shape[-1] == 3


### PR DESCRIPTION
## Summary

Completes the Protpardelle debugging work from ENG-75 / #257 on top of `mdc/add-protpardelle`.

This PR intentionally targets `mdc/add-protpardelle` so the review contains only the final Protpardelle fixes, not the whole in-progress integration branch.

Key changes:

- Restores the EDM sampler/model-wrapper call shape to the protocol-compatible `step(noisy_state, t_hat, features=features)` after removing the temporary extra `eps` argument.
- Implements Protpardelle step-time noise handling via `_expand_noise_level()`, broadcasting scalar or per-batch EDM timesteps to Protpardelle's expected `B x L` tensor.
- Moves Protpardelle step inputs/conditioning tensors onto the wrapper device before the model forward pass.
- Keeps `prot_lens_per_chain` on CPU when calling Protpardelle's sampling helper to avoid CPU/GPU device mismatch in helper-created residue indices.
- Maps Atomworks selenomethionine atom name `SE` into Protpardelle atom37's methionine sulfur slot `SD`.
- Fixes `ProtpardelleConditioning` immutability so dataclass construction can complete before selected conditioning fields become frozen.
- Allows packaged Protpardelle config/data under `src/sampleworks/data/**` through `.actlignore` so ACTL sync includes the runtime YAML config.
- Re-enables the slow `step()` behavior test and adds coverage for the MSE selenium atom mapping.

## Validation

Local static checks:

- `uvx ty check src/sampleworks/models/protpardelle/wrapper.py src/sampleworks/core/samplers/edm.py tests/models/protpardelle/test_protpardelle_wrapper.py`
- `uvx ruff check src/sampleworks/models/protpardelle/wrapper.py src/sampleworks/core/samplers/edm.py tests/models/protpardelle/test_protpardelle_wrapper.py`

Remote ACTL / Protpardelle environment checks:

- `pixi run -e protpardelle-dev pytest tests/models/protpardelle -m "not slow"`
  - `27 passed, 1 deselected`
- `pixi run -e protpardelle-dev pytest tests/models/protpardelle/test_protpardelle_wrapper.py::TestStep::test_step_returns_coords`
  - `1 passed`
- Exact reduced Protpardelle guidance smoke command from #257 using the shared checkpoint and 1VME inputs
  - completed successfully with `Guidance run successfully!`
  - wrote results to `output/protpardelle-smoke-guided/`

Non-blocking warnings observed during the smoke run were expected environment warnings for unavailable optional model/tool paths and missing mirror environment variables; they did not prevent the Protpardelle run from completing.

Refs #257.
