### PR TITLE
Separate diffuse runner used to build containers

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   sync_checkpoints:
     name: Sync checkpoints to Docker Hub
-    runs-on: astera-sh-builder
+    runs-on: diffuse-sh-builder
     permissions:
       contents: read
     outputs:
@@ -105,7 +105,7 @@ jobs:
 
   public:
     name: Public pixi-with-checkpoints image
-    runs-on: astera-sh-builder
+    runs-on: diffuse-sh-builder
     needs: sync_checkpoints
     permissions:
       contents: read
@@ -177,7 +177,7 @@ jobs:
 
   astera:
     name: Astera EXT image
-    runs-on: astera-sh-builder
+    runs-on: diffuse-sh-builder
     needs: public
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Docker publish jobs in `diff-use/sampleworks` were stuck waiting for a runner.

The issue started in commit `9f17fc4` (`Run docker workflow on Astera builder`), which changed the Docker workflow from `ubuntu-latest` to `astera-sh-builder`.

`astera-sh-builder` existed, but it was registered to the `Astera-org` GitHub org. The `sampleworks` repo is under `diff-use`, so GitHub could not match the job to that runner.

## Fix

Add a new diff-use CPU runner scale set named `diffuse-sh-builder` in the existing `arc-runners` namespace.

Update the `sampleworks` Docker workflow to use:

```yaml
runs-on: diffuse-sh-builder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to use a shared runner for several container-related jobs.
  * Kept the rest of the automation unchanged, including build steps, tagging, validation, and job dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->