### PR TITLE
Sampleworks container build fully fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CONDA_OVERRIDE_CUDA: "12"
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -210,8 +210,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern=v{{version}}
 
-      - name: Resolve public image input
-        id: public-ref
+      - name: Validate public image digest
         env:
           PUBLIC_IMAGE_DIGEST: ${{ needs.public.outputs.image-digest }}
         run: |
@@ -223,7 +222,6 @@ jobs:
             echo "public job produced a non-sha256 digest: ${PUBLIC_IMAGE_DIGEST}"
             exit 1
           fi
-          echo "image=${PUBLIC_REGISTRY}/${PUBLIC_IMAGE_NAME}@${PUBLIC_IMAGE_DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Astera image
         id: astera-build
@@ -236,7 +234,7 @@ jobs:
           tags: ${{ steps.astera-meta.outputs.tags }}
           labels: ${{ steps.astera-meta.outputs.labels }}
           build-args: |
-            PIXI_WITH_CHECKPOINTS_IMAGE=${{ steps.public-ref.outputs.image }}
+            PIXI_WITH_CHECKPOINTS_IMAGE=${{ env.PUBLIC_REGISTRY }}/${{ env.PUBLIC_IMAGE_NAME }}@${{ needs.public.outputs.image-digest }}
           cache-from: type=registry,ref=${{ env.ASTERA_REGISTRY }}/${{ env.ASTERA_IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.ASTERA_REGISTRY }}/${{ env.ASTERA_IMAGE_NAME }}:buildcache,mode=max,ignore-error=true
           provenance: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ name: Build and Push Docker Images
 
 on:
   push:
-    branches: [main, test-build]
+    branches: [main]
     tags:
       - 'v*.*.*'
   workflow_dispatch:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,7 +108,7 @@ jobs:
     permissions:
       contents: read
     outputs:
-      image-ref: ${{ steps.public-ref.outputs.image }}
+      image-digest: ${{ steps.public-build.outputs.digest }}
 
     steps:
       - name: Checkout code
@@ -172,12 +172,6 @@ jobs:
           cache-to: type=registry,ref=${{ env.PUBLIC_REGISTRY }}/${{ env.PUBLIC_IMAGE_NAME }}:buildcache,mode=max,ignore-error=true
           provenance: false
 
-      - name: Publish public image ref for Astera overlay
-        id: public-ref
-        run: |
-          short_sha="${GITHUB_SHA:0:${DOCKER_METADATA_SHORT_SHA_LENGTH}}"
-          echo "image=${PUBLIC_REGISTRY}/${PUBLIC_IMAGE_NAME}:sha-${short_sha}" >> "$GITHUB_OUTPUT"
-
       - name: Public image digest
         run: echo "Public image pushed with digest ${{ steps.public-build.outputs.digest }}"
 
@@ -216,6 +210,21 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern=v{{version}}
 
+      - name: Resolve public image input
+        id: public-ref
+        env:
+          PUBLIC_IMAGE_DIGEST: ${{ needs.public.outputs.image-digest }}
+        run: |
+          if [ -z "${PUBLIC_IMAGE_DIGEST}" ]; then
+            echo "public job did not produce an image digest."
+            exit 1
+          fi
+          if [ "${PUBLIC_IMAGE_DIGEST}" = "${PUBLIC_IMAGE_DIGEST#sha256:}" ]; then
+            echo "public job produced a non-sha256 digest: ${PUBLIC_IMAGE_DIGEST}"
+            exit 1
+          fi
+          echo "image=${PUBLIC_REGISTRY}/${PUBLIC_IMAGE_NAME}@${PUBLIC_IMAGE_DIGEST}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push Astera image
         id: astera-build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
@@ -227,7 +236,7 @@ jobs:
           tags: ${{ steps.astera-meta.outputs.tags }}
           labels: ${{ steps.astera-meta.outputs.labels }}
           build-args: |
-            PIXI_WITH_CHECKPOINTS_IMAGE=${{ needs.public.outputs.image-ref }}
+            PIXI_WITH_CHECKPOINTS_IMAGE=${{ steps.public-ref.outputs.image }}
           cache-from: type=registry,ref=${{ env.ASTERA_REGISTRY }}/${{ env.ASTERA_IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.ASTERA_REGISTRY }}/${{ env.ASTERA_IMAGE_NAME }}:buildcache,mode=max,ignore-error=true
           provenance: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ name: Build and Push Docker Images
 
 on:
   push:
-    branches: [main]
+    branches: [main, test-build]
     tags:
       - 'v*.*.*'
   workflow_dispatch:
@@ -169,7 +169,7 @@ jobs:
             BASE_IMAGE=${{ env.CUDA_BASE_IMAGE }}
             CHECKPOINTS_IMAGE=${{ steps.checkpoint-ref.outputs.image }}
           cache-from: type=registry,ref=${{ env.PUBLIC_REGISTRY }}/${{ env.PUBLIC_IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.PUBLIC_REGISTRY }}/${{ env.PUBLIC_IMAGE_NAME }}:buildcache,mode=max
+          cache-to: type=registry,ref=${{ env.PUBLIC_REGISTRY }}/${{ env.PUBLIC_IMAGE_NAME }}:buildcache,mode=max,ignore-error=true
           provenance: false
 
       - name: Publish public image ref for Astera overlay
@@ -229,7 +229,7 @@ jobs:
           build-args: |
             PIXI_WITH_CHECKPOINTS_IMAGE=${{ needs.public.outputs.image-ref }}
           cache-from: type=registry,ref=${{ env.ASTERA_REGISTRY }}/${{ env.ASTERA_IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.ASTERA_REGISTRY }}/${{ env.ASTERA_IMAGE_NAME }}:buildcache,mode=max
+          cache-to: type=registry,ref=${{ env.ASTERA_REGISTRY }}/${{ env.ASTERA_IMAGE_NAME }}:buildcache,mode=max,ignore-error=true
           provenance: false
 
       - name: Astera image digest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -198,6 +198,13 @@ jobs:
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_PASSWORD }}
 
+      - name: Login to public registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.PUBLIC_REGISTRY }}
+          username: ${{ secrets.SAMPLEWORKS_PUBLIC_REGISTRY_USERNAME || secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.SAMPLEWORKS_PUBLIC_REGISTRY_PASSWORD || secrets.DOCKERHUB_TOKEN }}
+
       - name: Docker metadata for Astera image
         id: astera-meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6


### PR DESCRIPTION
- Use the public image digest from the Docker build output instead of rebuilding a sha-* tag manually.
- Pass that digest-pinned public image into the Astera EXT image build.
- Add a small validation step so the Astera build fails early if the public image digest is missing or invalid.
- Login to the public registry before the Astera build, because it needs to pull the public image by digest.
- Make Docker build cache upload best-effort with ignore-error=true, so cache push failures do not fail the actual image release.
- Verified that the new Harbor image was pushed and contains ext plus the ext shell hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image handling to use a verified digest for handoff between build stages, reducing the risk of pulling the wrong image version.
  * Added validation to fail builds when the expected image digest is missing or not properly pinned.
  * Made build cache uploads more resilient so cache-related issues won’t fail the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->