### PR TITLE
fix(samplers): reconcile FlowModelWrapper.step call with Protocol

### DIFF
--- a/src/sampleworks/cli/guidance.py
+++ b/src/sampleworks/cli/guidance.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-from loguru import logger
 
 from sampleworks.utils.guidance_script_arguments import GuidanceConfig
 

--- a/src/sampleworks/core/samplers/edm.py
+++ b/src/sampleworks/core/samplers/edm.py
@@ -422,10 +422,8 @@ class AF3EDMSampler:
         # t_hat will be float if check_context didn't raise
         # Use no_grad when gradients aren't needed to avoid memory overhead from
         # gradient checkpointing holding intermediate activations
-        # TODO testing adding eps to signature for use with Protpardelle-1c, if successful,
-        #   I need to modify the Protocol itself. @Michael Anzuoni
         with torch.set_grad_enabled(allow_gradients):
-            x_hat_0 = model_wrapper.step(noisy_state, t_hat, eps, features=features)
+            x_hat_0 = model_wrapper.step(noisy_state, t_hat, features=features)
 
         reconciler = (
             context.reconciler.to(torch.as_tensor(x_hat_0).device)

--- a/src/sampleworks/models/protpardelle/wrapper.py
+++ b/src/sampleworks/models/protpardelle/wrapper.py
@@ -439,7 +439,7 @@ class ProtpardelleWrapper:
 
     def _atom37_indices_from_atom_array(
         self, atom_array
-    ) -> tuple[Int[Tensor, "atoms"], Int[Tensor, "atoms"]]:
+    ) -> tuple[Int[Tensor, " atoms"], Int[Tensor, " atoms"]]:
         """Derive per-atom atom37 destination indices from an Atomworks atom array.
 
         For each atom in ``atom_array`` (the order the sampler's flat ``x_t``
@@ -636,7 +636,6 @@ class ProtpardelleWrapper:
         self,
         x_t: Float[Tensor, "batch atoms 3"],
         t: Float[Tensor, "*batch"] | float,
-        sigma_float: float,
         *,
         features: GenerativeModelInput[ProtpardelleConditioning] | None = None,
     ) -> Float[Tensor, "batch atoms 3"]:

--- a/tests/runs/test_runner.py
+++ b/tests/runs/test_runner.py
@@ -265,7 +265,8 @@ def test_dry_run_does_not_create_directories(
     """--dry-run prints commands but never touches the filesystem."""
     monkeypatch.setenv("HOME", str(tmp_path))
     results_dir = tmp_path / "results"
-    preset = loader.load_preset("rf3_partial", overrides=["jobs.0.gpu_count=1"])  # use 1 gpu so we don't need big nodes to test
+    # use 1 gpu so we don't need big nodes to test
+    preset = loader.load_preset("rf3_partial", overrides=["jobs.0.gpu_count=1"])
     runner.run(preset, results_dir=results_dir, dry_run=True)
     # results_dir gets created by run() (for log file location) but per-job
     # output subdirs must NOT exist after dry-run.


### PR DESCRIPTION
## Summary

Fixes #283 and unbreaks CI on #274 (`mdc/add-protpardelle`).

The EDM sampler called `model_wrapper.step(noisy_state, t_hat, eps, features=features)`, passing a **third positional `eps`** that is not part of the `FlowModelWrapper.step(x_t, t, *, features=None)` protocol. Because boltz/protenix/rf3 (and the test mocks) implement the protocol exactly — no extra positional, no `**kwargs` — every sampler-path test failed with:

```
TypeError: <Wrapper>.step() takes 3 positional arguments but 4 positional arguments (and 1 keyword-only argument) were given
  src/sampleworks/core/samplers/edm.py:428
```

That single call site accounts for **all 164 failing tests** across the `boltz-dev` / `protenix-dev` / `rf3-dev` jobs (110 `MismatchCaseWrapper` + 54 `MockFlowModelWrapper`).

The extra argument was only ever absorbed by Protpardelle's `step()`, where it landed in a `sigma_float` parameter that is **never referenced** in the method body — so removing it changes no behavior. This matches @k-chrispens's note on #283 (already addressed by #267; `eps` is the noise tensor, not a noise level) and restores the resolution that was lost when the branch was force-updated.

## Changes

**Protocol reconciliation (#283)**
- `core/samplers/edm.py`: drop the extra `eps` positional from the `model_wrapper.step()` call. `eps` is still computed locally and used to build the noisy state and the working-frame guidance math — only the (dead) hand-off to the wrapper is removed. Deleted the temporary "I need to modify the Protocol itself" TODO.
- `models/protpardelle/wrapper.py`: remove the unused `sigma_float` parameter so `step()` matches `FlowModelWrapper`.

**Lint job (was failing, 8 errors)**
- `cli/guidance.py`: remove unused top-level `from loguru import logger` (it's re-imported inside `main()`) — fixes F401 / F811 / I001.
- `models/protpardelle/wrapper.py`: use the repo's existing leading-space single-axis jaxtyping convention (`Int[Tensor, " atoms"]`, as in `edm.py`/`step_scalers.py`) to avoid UP037 / F821.
- `tests/runs/test_runner.py`: wrap an over-length inline comment (E501).

## Validation
- `ruff 0.15.8 check` passes on all touched files locally (same version as CI).
- Test suites can't run on this macOS checkout (pixi envs are linux-64); CI on this PR exercises them. Every failing test traced to the removed `edm.py:428` positional and the tests already call `step(x, t, features=...)`, so they should go green.

Closes #283.