### PR TITLE
Adding CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,11 @@
+* @diff-use/sampleworks-core abbas@astera.org denis@astera.org @mag-astera
+
+/analyses/ @diff-use/sampleworks-core
+/docker/ @diff-use/sampleworks-core abbas@astera.org @mag-astera
+/experiments/ @diff-use/sampleworks-core
+
+# The core code should require scientist approval to merge
+/src/sampleworks/ @k-chrispens @marcuscollins @DorisMai
+
+/src/sampleworks/runs/ @diff-use/sampleworks-core abbas@astera.org
+/tests/ @diff-use/sampleworks-core


### PR DESCRIPTION
We'd like to have more control over who can approve PRs. Core developers should be added to the diff-use/sampleworks-core team. Once this is approved, we'll require approvals from people on these lists in order to merge code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository code ownership rules for key areas, including default ownership and path-specific ownership assignments.
  * Updated ownership coverage for analyses, experiments, docker assets, source code, and tests, with a new approval requirement on one source area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->