### PR TITLE
test(protenix): skip checkpoint fixture when weights absent instead of downloading

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -620,8 +620,13 @@ def boltz2_wrapper(boltz2_checkpoint_path: Path, device: torch.device):
 def protenix_checkpoint_path() -> Path:
     if not PROTENIX_AVAILABLE:
         pytest.skip("Protenix dependencies not installed in this environment")
-    # Protenix downloads checkpoint on first use if missing, so no existence check needed
-    return Path(getsitepackages()[0]) / "release_data/checkpoint/protenix_base_default_v0.5.0.pt"
+    # Protenix would auto-download the checkpoint on first use if missing. Skip instead of
+    # reaching out to the network so non-GPU/offline runs (e.g. CI) don't hang or time out
+    # constructing the wrapper (see #216). Provision the checkpoint to run these tests.
+    path = Path(getsitepackages()[0]) / "release_data/checkpoint/protenix_base_default_v0.5.0.pt"
+    if not path.exists():
+        pytest.skip(f"Protenix checkpoint not found at {path}")
+    return path
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary

Fixes #216 — the flaky "tests require a remote server / time out" failures.

The failing CI jobs were `tests/models/test_model_wrapper_protocol.py::...[protenix]`, timing out with `urllib.error.URLError: Connection timed out`. Root cause: the `protenix_checkpoint_path` fixture returned a path **without** checking it exists, with a comment noting Protenix auto-downloads on first use. The protocol tests resolve `protenix_wrapper` → `protenix_checkpoint_path` → `ProtenixWrapper.__init__` → `download_inference_cache(...)`, so in a no-weights CI environment they reach out to the network and hang/time out.

The `boltz1/boltz2/rf3` checkpoint fixtures already handle this correctly — they `pytest.skip` when the checkpoint file is missing. This makes the protenix fixture consistent:

```python
path = Path(getsitepackages()[0]) / "release_data/checkpoint/protenix_base_default_v0.5.0.pt"
if not path.exists():
    pytest.skip(f"Protenix checkpoint not found at {path}")
return path
```

Now non-GPU/offline runs skip the protenix protocol tests instead of triggering a network download; provisioning the checkpoint (as GPU/slow envs do) runs them as before.

Note: this intentionally removes the implicit auto-download-on-first-use for the test path — matching how boltz/rf3 require a pre-provisioned checkpoint. If CI is expected to fetch the protenix checkpoint out-of-band, shout and I'll adjust.

Closes #216.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup to handle missing Protenix checkpoint files more gracefully.
  * Tests now skip automatically when the required checkpoint is unavailable, helping avoid unintended network access during runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->