### PR TITLE
refactor(msa): remove unused Protenix a3m writes in _compute_msa

### DIFF
--- a/src/sampleworks/utils/msa.py
+++ b/src/sampleworks/utils/msa.py
@@ -229,46 +229,6 @@ def _compute_msa(
 
         outputs[name] = msa_path
 
-        """
-        a3m files for Protenix.
-        In case we weren't having enough fun, we need to write it all out in yet a third
-        # format, for use by Protenix. Protenix expects a JSON blob like so:
-        [
-          {
-            "sequences": [
-              {"proteinChain":
-                {
-                  "sequence": "ACDE...",
-                  "msa":
-                    {
-                      "precomputed_msa_dir:": "/path/to/msa_directory"
-                      "pairing_db": "uniref100"
-                    },
-                  ... other fields
-                }
-              }, ...
-            ]
-          }, ...
-        ]
-
-        It expects /path/to/msa_directory to look like this:
-        0:  # index corresponds to position in the list "sequences"
-            non_pairing.a3m
-            pairing.a3m  # only present if pairing was used.
-        1:
-            non_pairing.a3m
-            pairing.a3m
-        etc...
-        """
-
-        # TODO I don't think these are actually used anywhere. We can probably remove them.
-        msa_idx_idr = msa_dir / f"{idx}"
-        msa_idx_idr.mkdir(exist_ok=True, parents=True)
-        logger.info(f"Writing MSA for target {target_id} sequence {idx} to {msa_idx_idr.resolve()}")
-        msa_idx_idr.joinpath("non_pairing.a3m").write_text(unpaired_msa[idx])
-        if paired:
-            msa_idx_idr.joinpath("pairing.a3m").write_text(paired_msas[idx])
-
     return outputs
 
 

--- a/tests/utils/test_msa.py
+++ b/tests/utils/test_msa.py
@@ -192,3 +192,58 @@ def test_compute_msa_writes_matching_csv_and_a3m(tmp_path: Path):
     a3m_sequences = [line for i, line in enumerate(a3m_lines) if i % 2 == 1]
 
     assert csv_sequences == a3m_sequences == ["MKTAY", "MKTAC", "MKTAG"]
+
+
+# ============================================================================
+# get_msa Protenix cache path (regression guard)
+# ============================================================================
+
+
+def test_get_msa_protenix_caches_under_protenix_subdir_and_skips_second_search(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Protenix MSAs are cached under ``msa_dir/protenix/<hash>/<key>/`` (written by
+    ``protenix_msa_search``), independent of the boltz/rf3 ``_compute_msa`` path. A warm
+    cache must not re-invoke ``protenix_msa_search`` — that call is the live MSA-server
+    request we must not regress into. Also guards that the Protenix path does not depend
+    on any files under ``msa_dir/<idx>/``.
+    """
+    manager = MSAManager(msa_cache_dir=tmp_path)
+    data = {"A": "MKTAY"}
+    pairing = "greedy"
+    hash_key = MSAManager._hash_arguments(data, pairing)
+    out_dir = tmp_path / "protenix" / hash_key
+
+    call_count = {"n": 0}
+
+    def fake_protenix_search(sequences, search_out_dir, mode):
+        # Mirror protenix_msa_search: write per-key non_pairing/pairing.a3m into out_dir.
+        call_count["n"] += 1
+        search_out_dir = Path(search_out_dir)
+        dirs = []
+        for key in sorted(data.keys()):
+            d = search_out_dir / str(key)
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "non_pairing.a3m").write_text(f">{key}\n{data[key]}\n")
+            (d / "pairing.a3m").write_text(f">{key}\n{data[key]}\n")
+            dirs.append(d)
+        return dirs
+
+    monkeypatch.setattr(msa_module, "PROTENIX_AVAILABLE", True)
+    monkeypatch.setattr(msa_module, "protenix_msa_search", fake_protenix_search, raising=False)
+
+    # Cold cache: the search runs once and writes under msa_dir/protenix/<hash>/<key>/.
+    result = manager.get_msa(data, pairing, structure_predictor=StructurePredictor.PROTENIX)
+    assert call_count["n"] == 1
+    assert manager._api_calls == 1
+    assert manager._cache_hits == 0
+    assert (out_dir / "A" / "non_pairing.a3m").exists()
+    # The Protenix path never reads the (removed) msa_dir/<idx>/ files.
+    assert not (tmp_path / "0").exists()
+    assert result == {"A": out_dir / "A"}
+
+    # Warm cache: an identical request must NOT hit the MSA server again.
+    manager.get_msa(data, pairing, structure_predictor=StructurePredictor.PROTENIX)
+    assert call_count["n"] == 1
+    assert manager._api_calls == 1
+    assert manager._cache_hits == 1


### PR DESCRIPTION
## Summary

Fixes #179.

`_compute_msa` wrote per-sequence `non_pairing.a3m` / `pairing.a3m` files under `msa_dir/{idx}/`, guarded by a `# TODO I don't think these are actually used anywhere` comment. They aren't:

- The **boltz/rf3** path consumes the flat `{hash}_{n}.a3m` / `.csv` files validated by `_validate_msa_cache_contents`.
- The **Protenix** path reads `non_pairing.a3m` / `pairing.a3m` from a *different* directory — `msa_dir/protenix/<hash>/<idx>/` — produced by `protenix_msa_search`, never from the `msa_dir/{idx}/` location this block wrote.
- No test references these files (`grep tests/` for `non_pairing` / `pairing.a3m` → nothing).

Removed the dead writes plus the stale stray format-doc string that only described them. No consumers to update.

Closes #179.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MSA handling for Protenix requests so results are cached in the expected Protenix-specific location.
  * Prevented duplicate Protenix searches for repeated identical requests by reusing cached results.
  * Ensured standard MSA outputs remain separate from Protenix-specific cached files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->