### PR TITLE
docs(models): standardize model_atom_array docstring across wrappers

### DIFF
--- a/src/sampleworks/models/boltz/wrapper.py
+++ b/src/sampleworks/models/boltz/wrapper.py
@@ -288,8 +288,10 @@ class BoltzConditioning:
     true_atom_array : AtomArray | None
         Original structure's atom array (occupancy-filtered) for reward computation.
         Boltz's internal atom representation may differ from this due to padding, etc.
-        # TODO: figure out a standardized way of handling all these! related to several
-        todos elsewhere
+    model_atom_array : AtomArray | None
+        The AtomArray of the atoms the model actually operates on for the current
+        sequence. May differ from ``true_atom_array`` (padding, added/missing atoms,
+        element differences, etc.). Used for atom reconciliation against the true structure.
     """
 
     s: Tensor

--- a/src/sampleworks/models/protenix/wrapper.py
+++ b/src/sampleworks/models/protenix/wrapper.py
@@ -67,6 +67,10 @@ class ProtenixConditioning:
         Cached atom attention encoder output.
     true_atom_array : AtomArray | None
         The AtomArray of the true structure, used for alignment/evaluation.
+    model_atom_array : AtomArray | None
+        The AtomArray of the atoms the model actually operates on for the current
+        sequence. May differ from ``true_atom_array`` (padding, added/missing atoms,
+        element differences, etc.). Used for atom reconciliation against the true structure.
     """
 
     s_inputs: Tensor

--- a/src/sampleworks/models/rf3/wrapper.py
+++ b/src/sampleworks/models/rf3/wrapper.py
@@ -44,7 +44,9 @@ class RF3Conditioning:
     true_atom_array : AtomArray | None
         The AtomArray of the true structure, used for determining proper atom counts.
     model_atom_array : AtomArray | None
-        The AtomArray of the model's internal representation, used for atom reconciliation.
+        The AtomArray of the atoms the model actually operates on for the current
+        sequence. May differ from ``true_atom_array`` (padding, added/missing atoms,
+        element differences, etc.). Used for atom reconciliation against the true structure.
     """
 
     s_inputs: Tensor


### PR DESCRIPTION
## Summary

Fixes #109.

`model_atom_array` was documented inconsistently across the conditioning dataclasses, and `ProtenixConditioning` omitted it entirely. Standardized on one description across RF3 / Protenix / Boltz:

> The AtomArray of the atoms the model actually operates on for the current sequence. May differ from `true_atom_array` (padding, added/missing atoms, element differences, etc.). Used for atom reconciliation against the true structure.

Also resolves the `# TODO: figure out a standardized way of handling all these` note on `BoltzConditioning.true_atom_array`, since the naming/semantics are now documented consistently. Docs-only, no behavior change.

Closes #109.