### PR TITLE
fix(imports,tests): support bare require_* decorators; clean up protpardelle temp dirs

### DIFF
--- a/src/sampleworks/utils/imports.py
+++ b/src/sampleworks/utils/imports.py
@@ -76,6 +76,11 @@ def require_boltz(message: str | None = None) -> Callable[[F], F]:
     ... def custom_function():
     ...     pass
     """
+    if callable(message):
+        # Bare ``@require_boltz`` usage: the decorated function arrives as ``message``.
+        # Re-dispatch so both ``@require_boltz`` and ``@require_boltz("msg")`` work.
+        return require_boltz()(message)
+
     default_message = "Boltz model wrapper is not available. Install with: pixi install -e boltz"
 
     def decorator(func: F) -> F:
@@ -119,6 +124,11 @@ def require_protenix(message: str | None = None) -> Callable[[F], F]:
     ... def custom_function():
     ...     pass
     """
+    if callable(message):
+        # Bare ``@require_protenix`` usage: the decorated function arrives as ``message``.
+        # Re-dispatch so both ``@require_protenix`` and ``@require_protenix("msg")`` work.
+        return require_protenix()(message)
+
     default_message = (
         "Protenix model wrapper is not available. Install with: pixi install -e protenix"
     )
@@ -164,6 +174,11 @@ def require_rf3(message: str | None = None) -> Callable[[F], F]:
     ... def custom_function():
     ...     pass
     """
+    if callable(message):
+        # Bare ``@require_rf3`` usage: the decorated function arrives as ``message``.
+        # Re-dispatch so both ``@require_rf3`` and ``@require_rf3("msg")`` work.
+        return require_rf3()(message)
+
     default_message = "RF3 model wrapper is not available. Install with: pixi install -e rf3"
 
     def decorator(func: F) -> F:
@@ -207,6 +222,11 @@ def require_protpardelle(message: str | None = None) -> Callable[[F], F]:
     ... def custom_function():
     ...     pass
     """
+    if callable(message):
+        # Bare ``@require_protpardelle`` usage: the decorated function arrives as ``message``.
+        # Re-dispatch so both ``@require_protpardelle`` and ``@require_protpardelle("msg")`` work.
+        return require_protpardelle()(message)
+
     default_message = (
         "Protpardelle model wrapper is not available. Install with: pixi install -e protpardelle"
     )
@@ -252,6 +272,11 @@ def require_any_model(message: str | None = None) -> Callable[[F], F]:
     ... def custom_function():
     ...     pass
     """
+    if callable(message):
+        # Bare ``@require_any_model`` usage: the decorated function arrives as ``message``.
+        # Re-dispatch so both ``@require_any_model`` and ``@require_any_model("msg")`` work.
+        return require_any_model()(message)
+
     default_message = (
         "No model wrappers are available. "
         "Please install at least one model wrapper with the appropriate feature group: "

--- a/tests/models/protpardelle/conftest.py
+++ b/tests/models/protpardelle/conftest.py
@@ -6,7 +6,9 @@ directory to exist. The tests don't need real weights, so point
 imported, then build a small randomly-initialized ``ai-allatom`` model.
 """
 
+import atexit
 import os
+import shutil
 import tempfile
 import textwrap
 from pathlib import Path
@@ -14,11 +16,15 @@ from pathlib import Path
 import pytest
 
 
-# Must be set before any `import protpardelle...` happens. Respect an
-# externally configured directory (e.g. when real weights are available).
-os.environ.setdefault(
-    "PROTPARDELLE_MODEL_PARAMS", tempfile.mkdtemp(prefix="protpardelle_model_params_")
-)
+# Must be set before any `import protpardelle...` happens. Respect an externally
+# configured directory (e.g. when real weights are available); otherwise create a
+# throwaway dir and remove it at process exit so tests don't leak temp dirs.
+# `setdefault` can't own the created dir (it eagerly evaluates mkdtemp even when the
+# var is already set), so guard explicitly and register cleanup only when we created it.
+if "PROTPARDELLE_MODEL_PARAMS" not in os.environ:
+    _model_params_dir = tempfile.mkdtemp(prefix="protpardelle_model_params_")
+    os.environ["PROTPARDELLE_MODEL_PARAMS"] = _model_params_dir
+    atexit.register(shutil.rmtree, _model_params_dir, ignore_errors=True)
 
 protpardelle_models = pytest.importorskip(
     "protpardelle.core.models", reason="Protpardelle not installed in this environment"

--- a/tests/models/protpardelle/test_protpardelle_wrapper.py
+++ b/tests/models/protpardelle/test_protpardelle_wrapper.py
@@ -5,17 +5,23 @@ These tests build a small, randomly-initialized ``ai-allatom`` model (see
 needing downloaded weights.
 """
 
+import atexit
 import os
+import shutil
 import tempfile
 
 import pytest
 
 
-# Ensure the model-params directory exists before protpardelle is imported,
-# mirroring conftest (import order across conftests is not guaranteed).
-os.environ.setdefault(
-    "PROTPARDELLE_MODEL_PARAMS", tempfile.mkdtemp(prefix="protpardelle_model_params_")
-)
+# Ensure the model-params directory exists before protpardelle is imported, mirroring
+# conftest (import order across conftests is not guaranteed). Whichever module runs first
+# creates the throwaway dir and registers its cleanup; the other sees the var already set
+# and does nothing. Guard explicitly rather than `setdefault`, which would eagerly leak a
+# mkdtemp even when the var is present.
+if "PROTPARDELLE_MODEL_PARAMS" not in os.environ:
+    _model_params_dir = tempfile.mkdtemp(prefix="protpardelle_model_params_")
+    os.environ["PROTPARDELLE_MODEL_PARAMS"] = _model_params_dir
+    atexit.register(shutil.rmtree, _model_params_dir, ignore_errors=True)
 
 pytest.importorskip(
     "protpardelle.core.models", reason="Protpardelle not installed in this environment"


### PR DESCRIPTION
## Summary

Two P1 quick wins that live on this branch (both flagged by CodeRabbit on #274).

### #285 — `require_*` decorators don't support bare `@decorator` usage
The `require_protpardelle` factory (and its siblings `require_boltz` / `require_protenix` / `require_rf3` / `require_any_model`) only worked as `@require_x("msg")`. Used bare (`@require_x`), the decorated function was passed in as `message`, so the function was never wrapped/guarded — silently unprotected. Added a `callable(message)` check that re-dispatches through the factory, so **all three** forms now work:

```python
@require_protpardelle              # bare
@require_protpardelle()            # empty parens
@require_protpardelle("custom")    # with message
```

The docstrings' bare examples are now accurate. Every existing call site uses `@require_x()`, so no behavior change there.

### #286 — temp dirs leaked in protpardelle tests
`tests/models/protpardelle/conftest.py` and `test_protpardelle_wrapper.py` set the model-params dir with `os.environ.setdefault("PROTPARDELLE_MODEL_PARAMS", tempfile.mkdtemp(...))`. `setdefault` evaluates its default eagerly, so `mkdtemp()` ran — and leaked a dir — on **every** session even when the var was already set (e.g. real weights configured, or the other module already set it). Now guard on the var being unset, then register `atexit.register(shutil.rmtree, ..., ignore_errors=True)` so the throwaway dir is removed at process exit. Whichever module runs first owns creation+cleanup; the other no-ops.

Targets `mdc/add-protpardelle` since the affected code isn't on `main` yet.

Fixes #285. Fixes #286.