### PR TITLE
ci(codecov): collect and upload coverage from cpu-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,12 @@ jobs:
 
       - name: Run CPU tests
         run: pixi run -e ${{ matrix.environment }} cpu-tests
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          flags: ${{ matrix.environment }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # Don't fail the test job if the Codecov app/token isn't configured yet.
+          fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+# Codecov configuration — https://docs.codecov.com/docs/codecov-yaml
+#
+# Coverage is collected per model environment (boltz-dev / protenix-dev / rf3-dev)
+# in the `cpu-tests` CI job and uploaded with a matching flag, so per-env coverage
+# can be viewed independently and merged for the overall project number.
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: true
+
+flag_management:
+  default_rules:
+    carryforward: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ args = [{arg = "flags", default = ""}]
 cmd = "pytest {{ flags }}"
 
 [tool.pixi.tasks.cpu-tests]
-cmd = "pytest -m 'not gpu'"
+cmd = "pytest -m 'not gpu' --cov=sampleworks --cov-report=xml --cov-report=term"
 
 [tool.pixi.tasks.gpu-tests]
 cmd = "pytest -m gpu"


### PR DESCRIPTION
## Summary

Fixes #126.

Wires up Codecov:
- **Coverage collection** — `cpu-tests` now runs `pytest ... --cov=sampleworks --cov-report=xml --cov-report=term` (`pytest-cov` is already a dev/test dependency, so no new deps).
- **Upload step** — added a `codecov/codecov-action@v4` step to the `cpu-tests` job, flagged per model environment (`boltz-dev` / `protenix-dev` / `rf3-dev`) so per-env coverage is visible and merged for the overall number.
- **`codecov.yml`** — `auto` project/patch targets with a 1% threshold, per-flag carryforward, and diff comments on PRs.

### One maintainer step needed to activate
The upload uses `fail_ci_if_error: false`, so CI stays green regardless. To turn Codecov on:
1. Install the **Codecov GitHub app** on `diff-use/sampleworks`.
2. Add the repo's upload token as the **`CODECOV_TOKEN`** actions secret.

(Public repos can upload tokenless, but setting the token is the reliable path and required if the repo is private.)

Closes #126.