### PR TITLE
docs(deps): explain NumPy 1.x cap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,8 @@ PYTHONNOUSERSITE = "1"
 
 [tool.pixi.dependencies]
 ninja = "*"
+# boltz 2.2.1 requires numpy>=1.26,<2.0. Keep this workspace-wide cap until
+# Boltz supports NumPy 2.x so the shared boltz environments remain solvable.
 numpy = "<2.0"
 pyarrow = "==17.0.0"
 


### PR DESCRIPTION
## Summary
- document why the workspace remains capped below NumPy 2
- identify the exact locked dependency constraint (`boltz 2.2.1` requires `numpy>=1.26,<2.0`)
- make the condition for removing the cap explicit

Closes #276

## Validation
- parsed `pyproject.toml` with Python `tomllib`
- verified the locked Boltz 2.2.1 wheel metadata contains the NumPy `<2.0` requirement
- `git diff --check`