### PR TITLE
fix(tooling): align Ruff with Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,7 @@ testpaths = ["tests"]
 extend-include = ["*.ipynb"]
 line-length = 100
 src = []
-target-version = "py312"
+target-version = "py311"
 
 [tool.ruff.lint]
 fixable = ["I001", "F401", "UP"]


### PR DESCRIPTION
## Summary
- align Ruff's target version with the project's declared Python 3.11 minimum
- stop Ruff from recommending PEP 695 generic syntax that is a syntax error on a supported Python version
- retain the compatible `TypeVar` form until Python 3.11 support is intentionally dropped

Closes #311

## Validation
- `ruff check .`
- `ruff format --check .` (144 files already formatted)
- parsed `pyproject.toml` with Python `tomllib`
- `git diff --check`