### PR TITLE
feat(eval): generate synthetic sf mtz with Fprotein and Ftotal and correct cif saving

### DIFF
--- a/src/sampleworks/synthetic/generate_synthetic_sf.py
+++ b/src/sampleworks/synthetic/generate_synthetic_sf.py
@@ -196,10 +196,10 @@ def process_amplitudes_to_dataset(
         SFcalculator instance
     structure_factor_columns: dict[str, str]
         Mapping of ``label -> SFcalculator attribute``. Label must match the pattern of
-        SFcalculator attribute ``F{label}_asu`` (e.g. ``protein`` ->  ``Fprotein_asu``). 
-        One structure-factor set (``F{label}``/``SIGF{label}``/``PHIF{label}``) is 
+        SFcalculator attribute ``F{label}_asu`` (e.g. ``protein`` ->  ``Fprotein_asu``).
+        One structure-factor set (``F{label}``/``SIGF{label}``/``PHIF{label}``) is
         emitted per label, and multiple labels are merged into one MTZ sharing the same
-        HKL list (``miller_index_column``). For example, ``{"protein": "Fprotein_asu", 
+        HKL list (``miller_index_column``). For example, ``{"protein": "Fprotein_asu",
         "total": "Ftotal_asu"}`` produces ``Fprotein``/``SIGFprotein``/``PHIFprotein``/
         ``Ftotal``/``SIGFtotal``/``PHIFtotal`` and optionallyan R-free flag column.
     test_fraction: float

--- a/src/sampleworks/synthetic/generate_synthetic_sf.py
+++ b/src/sampleworks/synthetic/generate_synthetic_sf.py
@@ -1,9 +1,11 @@
 """Generate synthetic structure factor amplitudes via SFcalculator-torch.
 
-Produces an MTZ file of |Fmodel| (or |Fprotein| if not simulate solvent and
-scale) for each input PDB/mmCIF structure. The MTZ file has dummy values for
-SIGFP and optionally R-free flag column. Each structure can be optionally
-overridden with unit cell, space group, atom selection, and occupancy.
+For each input PDB/mmCIF structure, produces an MTZ file of protein structure factors
+only, or when ``--simulate-solvent-and-scale`` is set, both the protein and total sets
+(Fprotein/SIGFprotein/PHIFprotein and Ftotal/SIGFtotal/PHIFtotal) in the same
+MTZ. The MTZ file has dummy values for the SIGF column(s) and optionally an R-free flag
+column. Each structure can be optionally overridden with unit cell, space group, atom
+selection, and occupancy.
 """
 
 import argparse
@@ -25,6 +27,7 @@ from SFC_Torch.io import PDBParser
 from sampleworks.synthetic.synthetic_utils import (
     atomarray_to_gemmi,
     load_structure_for_synthetic_reward,
+    resolve_mtz_column,
     resolve_parallel_jobs,
     validate_occupancy_values,
 )
@@ -127,12 +130,60 @@ class BatchRowForMTZ:
         )
 
 
+def _build_rs_dataset_for_one_label(
+    sfc: SFcalculator,
+    label: str,
+    structure_factor_column: str,
+    miller_index_column: str,
+    sigma_f_scale: float,
+) -> rs.DataSet:
+    """Build an rs.DataSet that contains only one set of F / SIGF / PHIF columns.
+
+    ``sfc.prepare_dataset`` returns an amplitude column and a phase column (degrees)
+    for the given ``structure_factor_column`` attribute. We auto-detect those by MTZ
+    dtype (rather than assuming the unexposed ``FMODEL`` / ``PHIFMODEL`` names),
+    rename them to ``F{label}`` / ``PHIF{label}``, and synthesize a ``SIGF{label}``
+    column so several structure-factor sets (e.g. protein and total) can coexist in
+    one MTZ.
+
+    Parameters
+    ----------
+    sfc : SFcalculator
+        Structure-factor calculator holding the requested ASU amplitudes and phases.
+    label : str
+        Output column-label suffix, currenly only ``"protein"`` or ``"total"``, but
+        can also be solvent (mask) for debugging purposes.
+    structure_factor_column : str
+        SFcalculator attribute name passed to ``prepare_dataset`` (the amplitudes to emit).
+    miller_index_column : str
+        SFcalculator attribute name holding the Miller indices for ``prepare_dataset``.
+    sigma_f_scale : float
+        Multiplier used to synthesize the ``SIGF{label}`` column from the amplitudes.
+
+    Returns
+    -------
+    rs.DataSet
+        Dataset with columns ``F{label}``, ``SIGF{label}``, ``PHIF{label}`` (in that order).
+    """
+    dataset: rs.DataSet = sfc.prepare_dataset(miller_index_column, structure_factor_column)
+    amplitude_column = resolve_mtz_column(dataset, rs.StructureFactorAmplitudeDtype())
+    phase_column = resolve_mtz_column(dataset, rs.PhaseDtype())
+    logger.debug(
+        f"Auto-detected amplitude column: {amplitude_column}, "
+        f"phase column: {phase_column} for {label}"
+    )
+    f_col, phi_col, sig_col = f"F{label}", f"PHIF{label}", f"SIGF{label}"
+    dataset = dataset.rename(columns={amplitude_column: f_col, phase_column: phi_col})
+    dataset[sig_col] = (dataset[f_col] * sigma_f_scale).astype(rs.StandardDeviationDtype())
+    return dataset[[f_col, sig_col, phi_col]]
+
+
 def process_amplitudes_to_dataset(
     sfc: SFcalculator,
+    structure_factor_columns: dict[str, str],
     test_fraction: float = 0.05,
     seed: int | None = None,
     miller_index_column: str = "Hasu_array",
-    structure_factor_column: str = "Ftotal_asu",
     ccp4_convention: bool = False,
     sigma_f_scale: float = 0.2,
     output_path: Path | None = None,
@@ -143,14 +194,20 @@ def process_amplitudes_to_dataset(
     ----------
     sfc: SFcalculator
         SFcalculator instance
+    structure_factor_columns: dict[str, str]
+        Mapping of ``label -> SFcalculator attribute``. Label must match the pattern of
+        SFcalculator attribute ``F{label}_asu`` (e.g. ``protein`` ->  ``Fprotein_asu``). 
+        One structure-factor set (``F{label}``/``SIGF{label}``/``PHIF{label}``) is 
+        emitted per label, and multiple labels are merged into one MTZ sharing the same
+        HKL list (``miller_index_column``). For example, ``{"protein": "Fprotein_asu", 
+        "total": "Ftotal_asu"}`` produces ``Fprotein``/``SIGFprotein``/``PHIFprotein``/
+        ``Ftotal``/``SIGFtotal``/``PHIFtotal`` and optionallyan R-free flag column.
     test_fraction: float
         Fraction of reflections to mark as R-free test set (0 disables)
     seed: int | None
         Optional seed for reproducible R-free flag assignment
     miller_index_column: str
         Attribute name in SFcalculator for hkl indices
-    structure_factor_column: str
-        Attribute name in SFcalculator for structure factors
     ccp4_convention: bool
         If True, use CCP4 convention for R-free flag assignment. Default
         is False, which uses Phenix convention (1 = test, 0 = working).
@@ -164,18 +221,27 @@ def process_amplitudes_to_dataset(
     Returns
     -------
     rs.DataSet
-        Dataset with structure factor amplitudes, fake sigma column, and optionally
-        R-free flags.
+        Dataset with structure factor amplitudes, dummy sigma column(s), phases,
+        and optionally R-free flags.
     """
-    dataset: rs.DataSet = sfc.prepare_dataset(miller_index_column, structure_factor_column)
-    # assumes the first detected column of dtype F is the structure factor amplitude column
-    # avoids hardcoding unexposed column name "FMODEL" from sfc.prepare_dataset().
-    structure_factor_amplitude_column = dataset.select_mtzdtype(
-        rs.StructureFactorAmplitudeDtype()
-    ).columns[0]
-    sigma_f_column = f"SIG{structure_factor_amplitude_column}"
-    dataset[sigma_f_column] = dataset[structure_factor_amplitude_column] * sigma_f_scale
-    dataset[sigma_f_column] = dataset[sigma_f_column].astype(rs.StandardDeviationDtype())
+    # One dataset per label: for now just "protein" and "total", but it can generalizes
+    # to Fmask(solvent) which could be helpful for future debugging.
+    # All sets share the same HKL index, so this can be just a column-wise concat.
+    dataset: rs.DataSet | None = None
+    for label, attribute in structure_factor_columns.items():
+        ds = _build_rs_dataset_for_one_label(
+            sfc, label, attribute, miller_index_column, sigma_f_scale
+        )
+        if dataset is None:
+            dataset = ds
+        else:
+            dataset[ds.columns] = ds  # graft the remaining columns on (index-aligned)
+    if dataset is None:  # loop never ran -> the mapping was empty
+        raise ValueError(
+            "structure_factor_columns must contain at least one "
+            "'label -> SFcalculator attribute' entry (e.g. {'protein': 'Fprotein_asu'}), "
+            f"got {structure_factor_columns!r}."
+        )
     if test_fraction > 0:
         dataset = rs.utils.add_rfree(
             dataset,
@@ -238,8 +304,9 @@ def _process_single_row(
         If True, remove ligand molecules (non-water heteroatoms) before computing structure
         factors. Default is False.
     simulate_solvent_and_scale
-        If True, compute bulk solvent and scale factors for Ftotal instead of Fprotein.
-        Default is False.
+        If True, compute bulk solvent and scale factors and write a single MTZ containing
+        both the protein and total structure factor sets. If False (default), only the
+        protein set is written. One set contains F{label}/SIGF{label}/PHIF{label}.
     save_structure
         If True, save the processed structure (after selection and occupancy assignment)
         as mmCIF to output_dir. Unit cell and space group are preserved. Default is False.
@@ -304,15 +371,17 @@ def _process_single_row(
             f"n_atoms: {len(sfc.atom_pos_orth)}"
         )
         sfc.calc_fprotein()
+        structure_factor_columns = {"protein": "Fprotein_asu"}
         if simulate_solvent_and_scale:
             sfc.inspect_data()
             sfc.calc_fsolvent()
             sfc.init_scales(requires_grad=False)
             sfc.calc_ftotal()
-            F_attribute = "Ftotal_asu"
-        else:
-            F_attribute = "Fprotein_asu"
-        logger.debug(f"Computed {F_attribute} for {row.filename} on {device}")
+            structure_factor_columns.update({"total": "Ftotal_asu"})
+        logger.debug(
+            f"Computed {'Fprotein + Ftotal' if simulate_solvent_and_scale else 'Fprotein'} "
+            f"for {row.filename} on {device}"
+        )
     except Exception as e:
         logger.error(
             f"Failed to compute for {row.filename} ({type(e).__name__}): {e}\n"
@@ -325,7 +394,7 @@ def _process_single_row(
     try:
         process_amplitudes_to_dataset(
             sfc,
-            structure_factor_column=F_attribute,
+            structure_factor_columns=structure_factor_columns,
             test_fraction=test_fraction,
             seed=seed,
             output_path=output_path,
@@ -500,7 +569,12 @@ def parse_args() -> argparse.Namespace:
     sf_group.add_argument(
         "--simulate-solvent-and-scale",
         action="store_true",
-        help="Compute bulk solvent and overall scale factors (outputs Ftotal instead of Fprotein)",
+        help=(
+            "Compute bulk solvent and overall scale factors and write both protein and "
+            "total structure factor in one MTZ. Without this flag, protein only. Each set "
+            "is named by its label (either 'protein' or 'total') and contains: "
+            "F{label}/SIGF{label}/PHIF{label}."
+        ),
     )
     sf_group.add_argument(
         "--remove-hydrogens",

--- a/src/sampleworks/synthetic/generate_synthetic_sf.py
+++ b/src/sampleworks/synthetic/generate_synthetic_sf.py
@@ -14,7 +14,7 @@ import sys
 import traceback
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, cast, ClassVar
 
 import gemmi
 import reciprocalspaceship as rs
@@ -174,7 +174,11 @@ def _build_rs_dataset_for_one_label(
         f"phase column: {phase_column} for {label}"
     )
     f_col, phi_col, sig_col = f"F{label}", f"PHIF{label}", f"SIGF{label}"
-    dataset = dataset.rename(columns={amplitude_column: f_col, phase_column: phi_col})
+    # rs.DataSet.rename returns a DataSet at runtime, but the stub types it as DataFrame.
+    dataset = cast(
+        rs.DataSet,
+        dataset.rename(columns={amplitude_column: f_col, phase_column: phi_col}),
+    )
     dataset[sig_col] = (dataset[f_col] * sigma_f_scale).astype(rs.StandardDeviationDtype())
     return dataset[[f_col, sig_col, phi_col]]
 

--- a/src/sampleworks/synthetic/generate_synthetic_sf.py
+++ b/src/sampleworks/synthetic/generate_synthetic_sf.py
@@ -15,21 +15,19 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 import gemmi
-import numpy as np
 import reciprocalspaceship as rs
 import reciprocalspaceship.utils
 import torch
-from biotite.structure import AtomArray
 from loguru import logger
 from SFC_Torch import SFcalculator
-from SFC_Torch.io import array2hier, PDBParser
+from SFC_Torch.io import PDBParser
 
 from sampleworks.synthetic.synthetic_utils import (
+    atomarray_to_gemmi,
     load_structure_for_synthetic_reward,
     resolve_parallel_jobs,
     validate_occupancy_values,
 )
-from sampleworks.utils.atom_array_utils import BLANK_ALTLOC_IDS
 from sampleworks.utils.torch_utils import try_gpu
 
 
@@ -127,56 +125,6 @@ class BatchRowForMTZ:
             selection=row.get("selection") or None,
             occupancy_values=occupancy_values,
         )
-
-
-def atomarray_to_gemmi(
-    atom_array: AtomArray,
-    unit_cell: gemmi.UnitCell | None = None,
-    space_group: str | None = None,
-) -> gemmi.Structure:
-    """Convert a biotite AtomArray to a gemmi.Structure for SFcalculator.
-
-    Anisotropic B-factors are set to zero since biotite does not store them.
-    Blank altloc labels are converted from biotite's '' to gemmi's '\\x00'.
-
-    Parameters
-    ----------
-    atom_array
-        Input structure with occupancy and b_factor annotations
-    unit_cell
-        Crystallographic unit cell for the structure. If None, gemmi defaults
-        to (1.0, 1.0, 1.0, 90.0, 90.0, 90.0) in units of Angstroms and degrees.
-    space_group
-        Space group (in Hermann-Mauguin string format) for the structure. If
-        empty or invalid, SFcalculator defaults to P1.
-
-    Returns
-    -------
-    gemmi.Structure
-        Structure ready to be wrapped by SFC_Torch.io.PDBParser
-    """
-    n = len(atom_array)
-    cra_names = [
-        f"{atom_array.chain_id[i]}-0-{atom_array.res_name[i]}-{atom_array.atom_name[i]}"
-        for i in range(n)
-    ]
-    # gemmi uses '\x00' for blank altloc
-    atom_altloc = ["\x00" if a in BLANK_ALTLOC_IDS else a for a in atom_array.altloc_id]
-    structure: gemmi.Structure = array2hier(
-        atom_pos=atom_array.coord,
-        atom_b_aniso=np.zeros((n, 3, 3), dtype=np.float64),
-        atom_b_iso=atom_array.b_factor,
-        atom_occ=atom_array.occupancy,
-        atom_name=atom_array.element,
-        cra_name=cra_names,
-        atom_altloc=atom_altloc,
-        res_id=atom_array.res_id,
-    )
-    if unit_cell is not None:
-        structure.cell = unit_cell
-    if space_group is not None:
-        structure.spacegroup_hm = space_group
-    return structure
 
 
 def process_amplitudes_to_dataset(

--- a/src/sampleworks/synthetic/generate_synthetic_sf.py
+++ b/src/sampleworks/synthetic/generate_synthetic_sf.py
@@ -151,8 +151,9 @@ def _build_rs_dataset_for_one_label(
     sfc : SFcalculator
         Structure-factor calculator holding the requested ASU amplitudes and phases.
     label : str
-        Output column-label suffix, currenly only ``"protein"`` or ``"total"``, but
-        can also be solvent (mask) for debugging purposes.
+        Mtz column suffix. The resulted column names are ``F{label}``/``SIGF{label}``/
+        ``PHIF{label}``. The mtz column names should match what the structure-factor reward
+        later reads. In this script, we use ``"protein"`` and ``"total"`` as the labels.
     structure_factor_column : str
         SFcalculator attribute name passed to ``prepare_dataset`` (the amplitudes to emit).
     miller_index_column : str
@@ -224,9 +225,11 @@ def process_amplitudes_to_dataset(
         Dataset with structure factor amplitudes, dummy sigma column(s), phases,
         and optionally R-free flags.
     """
-    # One dataset per label: for now just "protein" and "total", but it can generalizes
-    # to Fmask(solvent) which could be helpful for future debugging.
-    # All sets share the same HKL index, so this can be just a column-wise concat.
+    # One dataset per label. Labels are free-form column suffixes (F{label}/SIGF{label}/
+    # PHIF{label}). User should supply the resulted column names when using the mtz for
+    # structure-factor reward. In this script, we use "protein" and "total" (for protein
+    # and bulk solvent) as the labels.
+    # All sets share the same HKL index, so this is just a column-wise concat.
     dataset: rs.DataSet | None = None
     for label, attribute in structure_factor_columns.items():
         ds = _build_rs_dataset_for_one_label(
@@ -235,6 +238,13 @@ def process_amplitudes_to_dataset(
         if dataset is None:
             dataset = ds
         else:
+            collisions = dataset.columns.intersection(ds.columns).tolist()
+            if collisions:
+                raise ValueError(
+                    f"Structure-factor label {label!r} would overwrite already-populated "
+                    f"column(s) {collisions} in the merged dataset. Ensure each label maps "
+                    "to a distinct set of column names."
+                )
             dataset[ds.columns] = ds  # graft the remaining columns on (index-aligned)
     if dataset is None:  # loop never ran -> the mapping was empty
         raise ValueError(

--- a/src/sampleworks/synthetic/synthetic_utils.py
+++ b/src/sampleworks/synthetic/synthetic_utils.py
@@ -419,9 +419,7 @@ def atomarray_to_gemmi(
             if current_chain is not None:
                 model.add_chain(current_chain)
             current_chain = gemmi.Chain(chain_id)
-        current_chain.add_residue(
-            _build_gemmi_residue(atom_array, start_idx, stop_idx, altlocs)
-        )
+        current_chain.add_residue(_build_gemmi_residue(atom_array, start_idx, stop_idx, altlocs))
     if current_chain is not None:  # flush the trailing chain
         model.add_chain(current_chain)
 

--- a/src/sampleworks/synthetic/synthetic_utils.py
+++ b/src/sampleworks/synthetic/synthetic_utils.py
@@ -2,6 +2,7 @@
 
 import math
 import traceback
+from collections.abc import Iterator
 from pathlib import Path
 
 import gemmi
@@ -308,8 +309,8 @@ def _resolve_altlocs_for_gemmi(atom_array: AtomArray) -> list[str]:
     return ["\x00" if a in BLANK_ALTLOC_IDS else a for a in atom_array.altloc_id]
 
 
-def _residue_group_bounds(atom_array: AtomArray) -> list[tuple[int, int]]:
-    """Return the atom-index spans, one per residue.
+def _residue_group_bounds(atom_array: AtomArray) -> Iterator[tuple[int, int]]:
+    """Yield the atom-index spans, one per residue.
 
     Parameters
     ----------
@@ -317,19 +318,19 @@ def _residue_group_bounds(atom_array: AtomArray) -> list[tuple[int, int]]:
         Structure whose atoms are grouped into residues. Atoms of a residue are
         assumed contiguous (true for arrays loaded in file order).
 
-    Returns
-    -------
-    list of tuple of int
+    Yields
+    ------
+    tuple of int
         One ``(start_idx, stop_idx)`` per residue, covering the atoms
         ``atom_array[start_idx:stop_idx]`` that share the same ``(chain_id, res_id)``.
     """
     if len(atom_array) == 0:
-        return []
+        return
     chain_id, res_id = atom_array.chain_id, atom_array.res_id
     # boundary shows where a new residue begins (i.e., chain or res_id changed).
     boundary = (chain_id[1:] != chain_id[:-1]) | (res_id[1:] != res_id[:-1])
     start_indices = [0, *(np.flatnonzero(boundary) + 1).tolist(), len(atom_array)]
-    return list(zip(start_indices[:-1], start_indices[1:]))
+    yield from zip(start_indices[:-1], start_indices[1:])
 
 
 def _build_gemmi_residue(
@@ -363,6 +364,8 @@ def _build_gemmi_residue(
     # if the subchain id is not set, gemmi's setup_entities() will set it to multi-char,
     # which is rejected by SFcalculator's PDB-header step.
     residue.subchain = atom_array.chain_id[start_idx]
+    # biotite's bool `hetero` -> gemmi's single-char het_flag ('H' HETATM / 'A' ATOM)
+    residue.het_flag = "H" if bool(atom_array.hetero[start_idx]) else "A"
     for atom_idx in range(start_idx, stop_idx):
         atom = gemmi.Atom()
         atom.name = atom_array.atom_name[atom_idx]

--- a/src/sampleworks/synthetic/synthetic_utils.py
+++ b/src/sampleworks/synthetic/synthetic_utils.py
@@ -6,11 +6,12 @@ from pathlib import Path
 
 import gemmi
 import numpy as np
+import reciprocalspaceship as rs
 import torch
 from atomworks.io.transforms.atom_array import remove_waters
 from biotite.structure import AtomArray
 from loguru import logger
-
+from reciprocalspaceship.dtypes.base import MTZDtype
 from sampleworks.utils.atom_array_utils import (
     AltlocInfo,
     apply_selection,
@@ -52,6 +53,61 @@ def resolve_parallel_jobs(device: torch.device | str, n_jobs: int) -> int:
         )
         return 1
     return n_jobs
+
+
+def resolve_mtz_column(
+    dataset: rs.DataSet,
+    dtype: MTZDtype,
+    *,
+    column: str | None = None,
+) -> str:
+    """Resolve the single column of the given MTZ dtype to use from ``dataset``.
+
+    Selects the dataset's columns of ``dtype`` and either validates a caller-supplied
+    ``column`` against them or returns the sole candidate, so callers need not extract the
+    candidate set themselves. Error messages label the dtype via ``dtype.name`` (e.g.
+    ``"SFAmplitude"``, ``"Stddev"``, ``"Phase"``).
+
+    Parameters
+    ----------
+    dataset
+        The reflection dataset (e.g. a parsed MTZ) whose columns are searched.
+    dtype
+        MTZ dtype selecting the candidate columns (e.g.
+        ``rs.StructureFactorAmplitudeDtype()``, ``rs.PhaseDtype()``).
+    column
+        Caller-chosen column. When given, it must be a ``dtype`` column of ``dataset`` and
+        is returned verbatim. When ``None``, the sole ``dtype`` column is returned.
+
+    Returns
+    -------
+    str
+        The resolved column name.
+
+    Raises
+    ------
+    ValueError
+        If ``column`` is given but is not a ``dtype`` column of ``dataset``, or ``column``
+        is ``None`` and the dataset holds zero or more than one ``dtype`` column (ambiguous
+        — the caller must disambiguate by passing ``column``).
+    """
+    dtype_name = dtype.name
+    candidates = list(dataset.select_mtzdtype(dtype).columns)
+    if not candidates:
+        raise ValueError(f"No {dtype_name} column found in the dataset.")
+    if column is not None:
+        if column not in candidates:
+            raise ValueError(
+                f"Requested {dtype_name} column {column!r} is not among the dataset's "
+                f"{dtype_name} columns: {candidates!r}."
+            )
+        return column
+    if len(candidates) > 1:
+        raise ValueError(
+            f"Multiple {dtype_name} columns {candidates} found; "
+            "pass an explicit column to disambiguate."
+        )
+    return candidates[0]
 
 
 def validate_occupancy_values(occupancy_values: list[float]) -> None:

--- a/src/sampleworks/synthetic/synthetic_utils.py
+++ b/src/sampleworks/synthetic/synthetic_utils.py
@@ -4,6 +4,8 @@ import math
 import traceback
 from pathlib import Path
 
+import gemmi
+import numpy as np
 import torch
 from atomworks.io.transforms.atom_array import remove_waters
 from biotite.structure import AtomArray
@@ -12,6 +14,7 @@ from loguru import logger
 from sampleworks.utils.atom_array_utils import (
     AltlocInfo,
     apply_selection,
+    BLANK_ALTLOC_IDS,
     detect_altlocs,
     keep_amino_acids,
     keep_polymer,
@@ -227,3 +230,150 @@ def load_structure_for_synthetic_reward(
         raise ValueError(f"Invalid occupancy mode '{occupancy_mode}'")
 
     return atom_array
+
+
+def _resolve_altlocs_for_gemmi(atom_array: AtomArray) -> list[str]:
+    """Resolve each atom's altloc label for gemmi, and standardize the blank altloc
+    to gemmi's convention ``'\\x00'``. If the atom array has no altloc_id annotation,
+    all atoms default to the blank altloc.
+
+    Parameters
+    ----------
+    atom_array : AtomArray
+        Structure whose ``altloc_id`` annotation (if present) is resolved.
+
+    Returns
+    -------
+    list of str
+        Per-atom altloc labels.
+    """
+    if "altloc_id" not in atom_array.get_annotation_categories():
+        return ["\x00"] * len(atom_array)
+    return ["\x00" if a in BLANK_ALTLOC_IDS else a for a in atom_array.altloc_id]
+
+
+def _residue_group_bounds(atom_array: AtomArray) -> list[tuple[int, int]]:
+    """Return the atom-index spans, one per residue.
+
+    Parameters
+    ----------
+    atom_array : AtomArray
+        Structure whose atoms are grouped into residues. Atoms of a residue are
+        assumed contiguous (true for arrays loaded in file order).
+
+    Returns
+    -------
+    list of tuple of int
+        One ``(start_idx, stop_idx)`` per residue, covering the atoms
+        ``atom_array[start_idx:stop_idx]`` that share the same ``(chain_id, res_id)``.
+    """
+    if len(atom_array) == 0:
+        return []
+    chain_id, res_id = atom_array.chain_id, atom_array.res_id
+    # boundary shows where a new residue begins (i.e., chain or res_id changed).
+    boundary = (chain_id[1:] != chain_id[:-1]) | (res_id[1:] != res_id[:-1])
+    start_indices = [0, *(np.flatnonzero(boundary) + 1).tolist(), len(atom_array)]
+    return list(zip(start_indices[:-1], start_indices[1:]))
+
+
+def _build_gemmi_residue(
+    atom_array: AtomArray, start_idx: int, stop_idx: int, altlocs: list[str]
+) -> gemmi.Residue:
+    """Build one gemmi.Residue from a contiguous span of atoms.
+
+    Parameters
+    ----------
+    atom_array : AtomArray
+        Structure supplying per-atom annotations.
+    start_idx : int
+        Inclusive atom index of the residue's first atom; per-residue fields
+        (name, seqid, subchain) are read from this atom.
+    stop_idx : int
+        Exclusive atom index marking the end of the residue's atom span.
+    altlocs : list of str
+        Per-atom altloc labels for the whole array (gemmi convention), indexed
+        globally by atom index -- not by a residue-local offset.
+
+    Returns
+    -------
+    gemmi.Residue
+        Residue populated with the atoms ``atom_array[start_idx:stop_idx]``.
+    """
+    res_id = int(atom_array.res_id[start_idx])
+    residue = gemmi.Residue()
+    residue.name = atom_array.res_name[start_idx]
+    residue.seqid = gemmi.SeqId(str(res_id))  # writes auth_seq_id
+    residue.label_seq = res_id  # writes label_seq_id, important for saving mmCIF
+    # if the subchain id is not set, gemmi's setup_entities() will set it to multi-char,
+    # which is rejected by SFcalculator's PDB-header step.
+    residue.subchain = atom_array.chain_id[start_idx]
+    for atom_idx in range(start_idx, stop_idx):
+        atom = gemmi.Atom()
+        atom.name = atom_array.atom_name[atom_idx]
+        atom.element = gemmi.Element(atom_array.element[atom_idx])
+        atom.pos = gemmi.Position(*atom_array.coord[atom_idx])  # (3,) float
+        atom.b_iso = float(atom_array.b_factor[atom_idx])
+        atom.aniso = gemmi.SMat33f(0, 0, 0, 0, 0, 0)  # biotite stores no anisotropic B
+        atom.occ = float(atom_array.occupancy[atom_idx])
+        atom.altloc = altlocs[atom_idx]
+        residue.add_atom(atom)
+    return residue
+
+
+def atomarray_to_gemmi(
+    atom_array: AtomArray,
+    unit_cell: gemmi.UnitCell | None = None,
+    space_group: str | None = None,
+) -> gemmi.Structure:
+    """Convert a biotite AtomArray to a gemmi.Structure for SFcalculator.
+
+    Anisotropic B-factors are set to zero since biotite does not store them.
+    Blank altloc labels are converted from biotite's '' to gemmi's '\\x00'. If
+    the atom array has no ``altloc_id`` annotation (e.g. arrays reconstructed by
+    a model wrapper), all altlocs default to blank.
+
+    Parameters
+    ----------
+    atom_array
+        Input structure with occupancy and b_factor annotations
+    unit_cell
+        Crystallographic unit cell for the structure. If None, gemmi defaults
+        to (1.0, 1.0, 1.0, 90.0, 90.0, 90.0) in units of Angstroms and degrees.
+    space_group
+        Space group (in Hermann-Mauguin string format) for the structure. If
+        empty or invalid, SFcalculator defaults to P1.
+
+    Returns
+    -------
+    gemmi.Structure
+        Structure ready to be wrapped by SFC_Torch.io.PDBParser
+    """
+    if len(atom_array) == 0:
+        raise ValueError("Cannot convert an empty AtomArray to a gemmi.Structure.")
+
+    altlocs = _resolve_altlocs_for_gemmi(atom_array)
+
+    # Group atoms into residues up front, then walk residues into chains. Contiguous
+    # grouping guarantees the hierarchy is well-formed by construction.
+    model = gemmi.Model("1")  # numeric name -> valid mmCIF pdbx_PDB_model_num
+    current_chain: gemmi.Chain | None = None
+    for start_idx, stop_idx in _residue_group_bounds(atom_array):
+        chain_id = atom_array.chain_id[start_idx]
+        if current_chain is None or chain_id != current_chain.name:
+            if current_chain is not None:
+                model.add_chain(current_chain)
+            current_chain = gemmi.Chain(chain_id)
+        current_chain.add_residue(
+            _build_gemmi_residue(atom_array, start_idx, stop_idx, altlocs)
+        )
+    if current_chain is not None:  # flush the trailing chain
+        model.add_chain(current_chain)
+
+    structure = gemmi.Structure()
+    structure.add_model(model)
+    structure.setup_entities()  # SFcalculator/PDBParser expects entities assigned
+    if unit_cell is not None:
+        structure.cell = unit_cell
+    if space_group is not None:
+        structure.spacegroup_hm = space_group
+    return structure

--- a/src/sampleworks/synthetic/synthetic_utils.py
+++ b/src/sampleworks/synthetic/synthetic_utils.py
@@ -13,6 +13,7 @@ from atomworks.io.transforms.atom_array import remove_waters
 from biotite.structure import AtomArray
 from loguru import logger
 from reciprocalspaceship.dtypes.base import MTZDtype
+
 from sampleworks.utils.atom_array_utils import (
     AltlocInfo,
     apply_selection,

--- a/tests/synthetic/test_generate_synthetic_sf.py
+++ b/tests/synthetic/test_generate_synthetic_sf.py
@@ -80,6 +80,18 @@ def _compute_fprotein(gemmi_structure: gemmi.Structure, device: torch.device) ->
     return assert_numpy(sfc.Fprotein_asu)
 
 
+def _dataset_with_columns(columns: dict[str, MTZDtype]) -> rs.DataSet:
+    """Build a minimal rs.DataSet with each column cast to its MTZ dtype.
+
+    Each column name maps to a dummy column cast to its MTZ dtype. The reflection index
+    is irrelevant to column resolution, so it is left default.
+    """
+    ds = rs.DataSet({name: [1.0, 2.0, 3.0] for name in columns})
+    for name, dtype in columns.items():
+        ds[name] = ds[name].astype(dtype)
+    return ds
+
+
 class TestAtomArrayToGemmi:
     """Tests for atomarray_to_gemmi using the 6b8x structure."""
 
@@ -251,61 +263,57 @@ class TestAtomArrayToGemmi:
         assert not np.allclose(np.abs(f_uniform), np.abs(f_custom), atol=1e-3)
 
 
-def _dataset_with_columns(columns: dict[str, MTZDtype]) -> rs.DataSet:
-    """Build a minimal rs.DataSet whose named columns carry the given MTZ dtypes.
-
-    Parameters
-    ----------
-    columns : dict of str to MTZDtype
-        Mapping from column name to the MTZ dtype that column should hold.
-
-    Returns
-    -------
-    rs.DataSet
-        Dataset with one dummy row per column, each column cast to its dtype. The
-        reflection index is irrelevant to column resolution, so it is left default.
-    """
-    ds = rs.DataSet({name: [1.0, 2.0, 3.0] for name in columns})
-    for name, dtype in columns.items():
-        ds[name] = ds[name].astype(dtype)
-    return ds
-
-
 class TestResolveMtzColumn:
     """Tests for resolve_mtz_column column-selection logic."""
 
-    def test_returns_sole_candidate(self):
+    @pytest.fixture
+    def dataset_with_amplitude_and_phase(self) -> rs.DataSet:
+        """One amplitude column (FP) and one phase column (PHI)."""
+        return _dataset_with_columns(
+            {"FP": rs.StructureFactorAmplitudeDtype(), "PHI": rs.PhaseDtype()}
+        )
+
+    @pytest.fixture
+    def dataset_with_single_amplitude(self) -> rs.DataSet:
+        """A sole amplitude column (FP), with no phase column present."""
+        return _dataset_with_columns({"FP": rs.StructureFactorAmplitudeDtype()})
+
+    @pytest.fixture
+    def dataset_with_two_amplitudes(self) -> rs.DataSet:
+        """Two amplitude columns (FP, FC) of the same dtype."""
+        return _dataset_with_columns(
+            {"FP": rs.StructureFactorAmplitudeDtype(), "FC": rs.StructureFactorAmplitudeDtype()}
+        )
+
+    def test_returns_sole_candidate(self, dataset_with_amplitude_and_phase):
         """With exactly one column of the dtype and no explicit choice, it is returned."""
-        ds = _dataset_with_columns(
-            {"FP": rs.StructureFactorAmplitudeDtype(), "PHI": rs.PhaseDtype()}
+        assert (
+            resolve_mtz_column(dataset_with_amplitude_and_phase, rs.StructureFactorAmplitudeDtype())
+            == "FP"
         )
-        assert resolve_mtz_column(ds, rs.StructureFactorAmplitudeDtype()) == "FP"
 
-    def test_no_candidate_raises(self):
+    def test_no_candidate_raises(self, dataset_with_single_amplitude):
         """A dtype absent from the dataset fails fast."""
-        ds = _dataset_with_columns({"FP": rs.StructureFactorAmplitudeDtype()})
         with pytest.raises(ValueError, match="column found"):
-            resolve_mtz_column(ds, rs.PhaseDtype())
+            resolve_mtz_column(dataset_with_single_amplitude, rs.PhaseDtype())
 
-    def test_ambiguous_candidates_raise(self):
+    def test_ambiguous_candidates_raise(self, dataset_with_two_amplitudes):
         """Two columns of the dtype with no explicit choice is ambiguous."""
-        ds = _dataset_with_columns(
-            {"FP": rs.StructureFactorAmplitudeDtype(), "FC": rs.StructureFactorAmplitudeDtype()}
-        )
         with pytest.raises(ValueError, match="Multiple"):
-            resolve_mtz_column(ds, rs.StructureFactorAmplitudeDtype())
+            resolve_mtz_column(dataset_with_two_amplitudes, rs.StructureFactorAmplitudeDtype())
 
-    def test_explicit_column_disambiguates(self):
+    def test_explicit_column_disambiguates(self, dataset_with_two_amplitudes):
         """An explicit column among the candidates is returned verbatim."""
-        ds = _dataset_with_columns(
-            {"FP": rs.StructureFactorAmplitudeDtype(), "FC": rs.StructureFactorAmplitudeDtype()}
+        assert (
+            resolve_mtz_column(
+                dataset_with_two_amplitudes, rs.StructureFactorAmplitudeDtype(), column="FC"
+            )
+            == "FC"
         )
-        assert resolve_mtz_column(ds, rs.StructureFactorAmplitudeDtype(), column="FC") == "FC"
 
-    def test_explicit_column_of_wrong_dtype_raises(self):
+    def test_explicit_column_of_wrong_dtype_raises(self, dataset_with_amplitude_and_phase):
         """An explicit column that is not of the requested dtype is rejected."""
-        ds = _dataset_with_columns(
-            {"FP": rs.StructureFactorAmplitudeDtype(), "PHI": rs.PhaseDtype()}
-        )
         with pytest.raises(ValueError, match="not among"):
-            resolve_mtz_column(ds, rs.StructureFactorAmplitudeDtype(), column="PHI")
+            resolve_mtz_column(
+                dataset_with_amplitude_and_phase, rs.StructureFactorAmplitudeDtype(), column="PHI"
+            )

--- a/tests/synthetic/test_generate_synthetic_sf.py
+++ b/tests/synthetic/test_generate_synthetic_sf.py
@@ -1,4 +1,4 @@
-"""Tests for atomarray_to_gemmi in generate_synthetic_sf, using real 6b8x structure."""
+"""Tests for atomarray_to_gemmi in synthetic_utils, using real 6b8x structure."""
 
 import logging
 from pathlib import Path
@@ -9,10 +9,10 @@ import pytest
 import torch
 from atomworks.io.transforms.atom_array import remove_waters
 from biotite.structure import AtomArray
-from sampleworks.synthetic.generate_synthetic_sf import atomarray_to_gemmi
-from sampleworks.synthetic.synthetic_utils import assign_occupancies
+from sampleworks.synthetic.synthetic_utils import assign_occupancies, atomarray_to_gemmi
 from sampleworks.utils.atom_array_utils import (
     detect_altlocs,
+    find_all_altloc_ids,
     keep_amino_acids,
     keep_polymer,
     load_structure_with_altlocs,
@@ -93,7 +93,8 @@ class TestAtomArrayToGemmi:
 
     def test_atoms_match_pdb(self, gemmi_structure_from_atomarray, stripped_gemmi):
         """Atom names and positions match the original PDB, in the same order."""
-        # atom order is preserved: biotite keeps PDB file order, array2hier reconstructs it
+        # atom order is preserved: biotite keeps PDB file order, and atomarray_to_gemmi
+        # emits atoms in that same order
         parser_from_atomarray = PDBParser(gemmi_structure_from_atomarray)
         parser_from_gemmi = PDBParser(stripped_gemmi)
         assert np.array_equal(parser_from_atomarray.atom_name, parser_from_gemmi.atom_name)
@@ -120,6 +121,83 @@ class TestAtomArrayToGemmi:
         f_atomarray = _compute_fprotein(gemmi_structure_from_atomarray, device)
         f_direct = _compute_fprotein(stripped_gemmi, device)
         np.testing.assert_allclose(np.abs(f_atomarray), np.abs(f_direct), atol=1e-3)
+
+    def test_saved_structure_round_trips_annotations(
+        self, gemmi_structure_from_atomarray, stripped_atom_array, tmp_path
+    ):
+        """Every per-atom field must survive atomarray_to_gemmi --> cif --> atomarray.
+
+        One reload guarding each column a write can silently drop/garble. Scattering-physics
+        fields (coords, element, b_factor, occupancy) would corrupt structure factors without
+        raising if lost; topology fields (chain_id, res_id, res_name, atom_name) drive residue/
+        altloc matching and reconciliation. res_id and label_seq_id are the field that regressed:
+        array2hier set only the author seqid, so label_seq_id wrote as "." and atomworks (label
+        scheme) collapsed every residue to -1 on re-read.
+        """
+        out = tmp_path / "saved.cif"
+        gemmi_structure_from_atomarray.make_mmcif_document().write_file(str(out))
+
+        loaded = load_structure_with_altlocs(out)
+        ref = stripped_atom_array
+
+        assert len(loaded) == len(ref)
+
+        # topology / matching labels (exact)
+        assert np.array_equal(loaded.chain_id, ref.chain_id)
+        assert np.array_equal(loaded.res_id, ref.res_id)
+        assert set(np.unique(loaded.res_id)) != {-1}  # not collapsed to the degenerate -1
+        assert np.array_equal(loaded.res_name, ref.res_name)
+        assert np.array_equal(loaded.atom_name, ref.atom_name)
+
+        # scattering-physics fields (element exact; floats within mmCIF write precision)
+        assert np.array_equal(loaded.element, ref.element)
+        assert len(np.unique(loaded.element)) > 1  # not collapsed to a single/blank symbol
+        np.testing.assert_allclose(loaded.coord, ref.coord, atol=1e-3)
+        np.testing.assert_allclose(loaded.b_factor, ref.b_factor, atol=1e-2)
+        np.testing.assert_allclose(loaded.occupancy, ref.occupancy, atol=1e-2)
+
+        # altloc: same id set, and same per-id atom counts
+        assert "altloc_id" in loaded.get_annotation_categories()
+        expected_altloc_ids = find_all_altloc_ids(ref)
+        assert find_all_altloc_ids(loaded) == expected_altloc_ids
+        for altloc_id in expected_altloc_ids:
+            assert np.count_nonzero(loaded.altloc_id == altloc_id) == np.count_nonzero(
+                ref.altloc_id == altloc_id
+            )
+
+    def test_multichain_shared_res_ids_survive_round_trip(self, tmp_path):
+        """Two chains that share res_ids must not be merged across the chain boundary.
+
+        array2hier keyed residue boundaries on res_id alone, so a chain boundary where both
+        sides share a res_id (chains independently numbered from 1) merged the two residues.
+        The direct builder keys on (chain_id, res_id); this guards that.
+        """
+        # Two chains A and B, each with residues 1 and 2 (overlapping numbering).
+        n = 4
+        arr = AtomArray(n)
+        arr.coord = np.arange(n * 3, dtype=np.float32).reshape(n, 3)
+        arr.chain_id = np.array(["A", "A", "B", "B"])
+        arr.res_id = np.array([1, 2, 1, 2])
+        arr.res_name = np.array(["ALA", "GLY", "ALA", "GLY"])
+        arr.atom_name = np.array(["CA", "CA", "CA", "CA"])
+        arr.element = np.array(["C", "C", "C", "C"])
+        arr.set_annotation("b_factor", np.full(n, 20.0))
+        arr.set_annotation("occupancy", np.ones(n))
+
+        out = tmp_path / "multichain.cif"
+        atomarray_to_gemmi(arr).make_mmcif_document().write_file(str(out))
+        loaded = load_structure_with_altlocs(out)
+
+        assert len(loaded) == n
+        assert np.array_equal(loaded.chain_id, arr.chain_id)
+        assert np.array_equal(loaded.res_id, arr.res_id)
+        # distinct per-atom coords pin identity+order: a boundary merge would drop/reorder atoms
+        np.testing.assert_allclose(loaded.coord, arr.coord, atol=1e-3)
+
+    def test_empty_atom_array_raises(self):
+        """An empty AtomArray fails fast rather than yielding a chain-less structure."""
+        with pytest.raises(ValueError, match="empty AtomArray"):
+            atomarray_to_gemmi(AtomArray(0))
 
     def test_occupancy_warns_on_extra_values(self, stripped_atom_array, caplog):
         """A warning is logged when more occupancy values are provided than there are altlocs."""

--- a/tests/synthetic/test_generate_synthetic_sf.py
+++ b/tests/synthetic/test_generate_synthetic_sf.py
@@ -1,4 +1,5 @@
-"""Tests for atomarray_to_gemmi in synthetic_utils, using real 6b8x structure."""
+"""Tests for synthetic_utils: atomarray_to_gemmi (real 6b8x structure) and
+resolve_mtz_column (in-memory datasets)."""
 
 import logging
 from pathlib import Path
@@ -6,10 +7,16 @@ from pathlib import Path
 import gemmi
 import numpy as np
 import pytest
+import reciprocalspaceship as rs
 import torch
 from atomworks.io.transforms.atom_array import remove_waters
 from biotite.structure import AtomArray
-from sampleworks.synthetic.synthetic_utils import assign_occupancies, atomarray_to_gemmi
+from reciprocalspaceship.dtypes.base import MTZDtype
+from sampleworks.synthetic.synthetic_utils import (
+    assign_occupancies,
+    atomarray_to_gemmi,
+    resolve_mtz_column,
+)
 from sampleworks.utils.atom_array_utils import (
     detect_altlocs,
     find_all_altloc_ids,
@@ -242,3 +249,65 @@ class TestAtomArrayToGemmi:
         )
 
         assert not np.allclose(np.abs(f_uniform), np.abs(f_custom), atol=1e-3)
+
+
+def _dataset_with_columns(columns: dict[str, MTZDtype]) -> rs.DataSet:
+    """Build a minimal rs.DataSet whose named columns carry the given MTZ dtypes.
+
+    Parameters
+    ----------
+    columns : dict of str to MTZDtype
+        Mapping from column name to the MTZ dtype that column should hold.
+
+    Returns
+    -------
+    rs.DataSet
+        Dataset with one dummy row per column, each column cast to its dtype. The
+        reflection index is irrelevant to column resolution, so it is left default.
+    """
+    ds = rs.DataSet({name: [1.0, 2.0, 3.0] for name in columns})
+    for name, dtype in columns.items():
+        ds[name] = ds[name].astype(dtype)
+    return ds
+
+
+class TestResolveMtzColumn:
+    """Tests for resolve_mtz_column column-selection logic."""
+
+    def test_returns_sole_candidate(self):
+        """With exactly one column of the dtype and no explicit choice, it is returned."""
+        ds = _dataset_with_columns(
+            {"FP": rs.StructureFactorAmplitudeDtype(), "PHI": rs.PhaseDtype()}
+        )
+        assert resolve_mtz_column(ds, rs.StructureFactorAmplitudeDtype()) == "FP"
+
+    def test_no_candidate_raises(self):
+        """A dtype absent from the dataset fails fast."""
+        ds = _dataset_with_columns({"FP": rs.StructureFactorAmplitudeDtype()})
+        with pytest.raises(ValueError, match="column found"):
+            resolve_mtz_column(ds, rs.PhaseDtype())
+
+    def test_ambiguous_candidates_raise(self):
+        """Two columns of the dtype with no explicit choice is ambiguous."""
+        ds = _dataset_with_columns(
+            {"FP": rs.StructureFactorAmplitudeDtype(), "FC": rs.StructureFactorAmplitudeDtype()}
+        )
+        with pytest.raises(ValueError, match="Multiple"):
+            resolve_mtz_column(ds, rs.StructureFactorAmplitudeDtype())
+
+    def test_explicit_column_disambiguates(self):
+        """An explicit column among the candidates is returned verbatim."""
+        ds = _dataset_with_columns(
+            {"FP": rs.StructureFactorAmplitudeDtype(), "FC": rs.StructureFactorAmplitudeDtype()}
+        )
+        assert (
+            resolve_mtz_column(ds, rs.StructureFactorAmplitudeDtype(), column="FC") == "FC"
+        )
+
+    def test_explicit_column_of_wrong_dtype_raises(self):
+        """An explicit column that is not of the requested dtype is rejected."""
+        ds = _dataset_with_columns(
+            {"FP": rs.StructureFactorAmplitudeDtype(), "PHI": rs.PhaseDtype()}
+        )
+        with pytest.raises(ValueError, match="not among"):
+            resolve_mtz_column(ds, rs.StructureFactorAmplitudeDtype(), column="PHI")

--- a/tests/synthetic/test_generate_synthetic_sf.py
+++ b/tests/synthetic/test_generate_synthetic_sf.py
@@ -169,7 +169,7 @@ class TestAtomArrayToGemmi:
         self, stripped_atom_array, stripped_gemmi, tmp_path
     ):
         """Test that reloading Gemmi's CIF output returns the original atom array used to construct
-        the Gemmi Structure object. This ensures we don't corrupt or lose information in building 
+        the Gemmi Structure object. This ensures we don't corrupt or lose information in building
         the Gemmi Structure that would affect our structure factor calculations.
 
         Fields (coords, element, b_factor, occupancy) drive the structure factors; fields
@@ -180,9 +180,7 @@ class TestAtomArrayToGemmi:
         """
         ref = stripped_atom_array
         save_cif_path = tmp_path / "saved.cif"
-        gemmi_structure = atomarray_to_gemmi(
-            ref, stripped_gemmi.cell, stripped_gemmi.spacegroup_hm
-        )
+        gemmi_structure = atomarray_to_gemmi(ref, stripped_gemmi.cell, stripped_gemmi.spacegroup_hm)
         gemmi_structure.make_mmcif_document().write_file(str(save_cif_path))
         loaded = load_structure_with_altlocs(save_cif_path)
 
@@ -191,8 +189,15 @@ class TestAtomArrayToGemmi:
         # Extra fields can exist depending on the structure file. For example, cif vs pdb would
         # have an extra annotation is_polymer. Here, we specify the key fields we care about.
         important_annotations = {
-            "chain_id", "res_id", "res_name", "atom_name", "element", "hetero",
-            "b_factor", "occupancy", "altloc_id",
+            "chain_id",
+            "res_id",
+            "res_name",
+            "atom_name",
+            "element",
+            "hetero",
+            "b_factor",
+            "occupancy",
+            "altloc_id",
         }
         assert important_annotations <= set(ref.get_annotation_categories())
         assert important_annotations <= set(loaded.get_annotation_categories())
@@ -206,9 +211,9 @@ class TestAtomArrayToGemmi:
 
         # Check the non-float annotation columns are identical
         for category in sorted(important_annotations - {"b_factor", "occupancy", "altloc_id"}):
-            assert np.array_equal(
-                loaded.get_annotation(category), ref.get_annotation(category)
-            ), f"annotation {category!r} did not round-trip"
+            assert np.array_equal(loaded.get_annotation(category), ref.get_annotation(category)), (
+                f"annotation {category!r} did not round-trip"
+            )
 
         assert set(np.unique(loaded.res_id)) != {-1}  # not collapsed to the degenerate -1
         assert len(np.unique(loaded.element)) > 1  # not collapsed to a single/blank symbol
@@ -218,9 +223,7 @@ class TestAtomArrayToGemmi:
         np.testing.assert_allclose(loaded.b_factor, ref.b_factor, atol=1e-2)
         np.testing.assert_allclose(loaded.occupancy, ref.occupancy, atol=1e-2)
 
-    def test_multichain_shared_res_ids_not_merged_in_gemmi(
-        self, multichain_shared_resid_array
-    ):
+    def test_multichain_shared_res_ids_not_merged_in_gemmi(self, multichain_shared_resid_array):
         """Test that atomarray_to_gemmi splits shared res_ids into separate residues per chain
         in the Gemmi Structure object.
         """
@@ -239,9 +242,7 @@ class TestAtomArrayToGemmi:
             # residue, changing chain A's atom count and dropping chain B's atom -- breaking these.
             assert [res.seqid.num for res in residues] == arr.res_id[mask].tolist()
             assert [res.name for res in residues] == arr.res_name[mask].tolist()
-            assert [
-                atom.name for res in residues for atom in res
-            ] == arr.atom_name[mask].tolist()
+            assert [atom.name for res in residues for atom in res] == arr.atom_name[mask].tolist()
 
     def test_empty_atom_array_raises(self):
         """An empty AtomArray fails fast rather than yielding a chain-less structure."""

--- a/tests/synthetic/test_generate_synthetic_sf.py
+++ b/tests/synthetic/test_generate_synthetic_sf.py
@@ -300,9 +300,7 @@ class TestResolveMtzColumn:
         ds = _dataset_with_columns(
             {"FP": rs.StructureFactorAmplitudeDtype(), "FC": rs.StructureFactorAmplitudeDtype()}
         )
-        assert (
-            resolve_mtz_column(ds, rs.StructureFactorAmplitudeDtype(), column="FC") == "FC"
-        )
+        assert resolve_mtz_column(ds, rs.StructureFactorAmplitudeDtype(), column="FC") == "FC"
 
     def test_explicit_column_of_wrong_dtype_raises(self):
         """An explicit column that is not of the requested dtype is rejected."""

--- a/tests/synthetic/test_generate_synthetic_sf.py
+++ b/tests/synthetic/test_generate_synthetic_sf.py
@@ -18,6 +18,7 @@ from sampleworks.synthetic.synthetic_utils import (
     resolve_mtz_column,
 )
 from sampleworks.utils.atom_array_utils import (
+    BLANK_ALTLOC_IDS,
     detect_altlocs,
     find_all_altloc_ids,
     keep_amino_acids,
@@ -95,6 +96,29 @@ def _dataset_with_columns(columns: dict[str, MTZDtype]) -> rs.DataSet:
 class TestAtomArrayToGemmi:
     """Tests for atomarray_to_gemmi using the 6b8x structure."""
 
+    @pytest.fixture
+    def multichain_shared_resid_array(self) -> AtomArray:
+        """Two chains A (residues 1, 2) and B (residues 2, 3) that collide at the boundary.
+
+        Chain A's last residue and chain B's first residue both have res_id 2 and are
+        adjacent in atom order, so residue grouping keyed on res_id alone would merge them
+        into a single residue across the chain boundary. This collision at the chain
+        boundary is exactly what exercises the chain_id term of the grouping predicate --
+        a fixture whose res_id merely changes at the boundary (e.g. 2 -> 1) would split
+        correctly with or without that term and so would not guard it.
+        """
+        n = 4
+        arr = AtomArray(n)
+        arr.coord = np.arange(n * 3, dtype=np.float32).reshape(n, 3)
+        arr.chain_id = np.array(["A", "A", "B", "B"])
+        arr.res_id = np.array([1, 2, 2, 3])
+        arr.res_name = np.array(["ALA", "GLY", "GLY", "ALA"])
+        arr.atom_name = np.array(["CA", "CA", "CA", "CA"])
+        arr.element = np.array(["C", "C", "C", "C"])
+        arr.set_annotation("b_factor", np.full(n, 20.0))
+        arr.set_annotation("occupancy", np.ones(n))
+        return arr
+
     def test_cell_matches_pdb(self, gemmi_structure_from_atomarray, stripped_gemmi):
         """Unit cell parameters are preserved through the biotite→gemmi conversion."""
         result = gemmi_structure_from_atomarray.cell
@@ -142,76 +166,82 @@ class TestAtomArrayToGemmi:
         np.testing.assert_allclose(np.abs(f_atomarray), np.abs(f_direct), atol=1e-3)
 
     def test_saved_structure_round_trips_annotations(
-        self, gemmi_structure_from_atomarray, stripped_atom_array, tmp_path
+        self, stripped_atom_array, stripped_gemmi, tmp_path
     ):
-        """Every per-atom field must survive atomarray_to_gemmi --> cif --> atomarray.
+        """Test that reloading Gemmi's CIF output returns the original atom array used to construct
+        the Gemmi Structure object. This ensures we don't corrupt or lose information in building 
+        the Gemmi Structure that would affect our structure factor calculations.
 
-        One reload guarding each column a write can silently drop/garble. Scattering-physics
-        fields (coords, element, b_factor, occupancy) would corrupt structure factors without
-        raising if lost; topology fields (chain_id, res_id, res_name, atom_name) drive residue/
-        altloc matching and reconciliation. res_id and label_seq_id are the field that regressed:
-        array2hier set only the author seqid, so label_seq_id wrote as "." and atomworks (label
-        scheme) collapsed every residue to -1 on re-read.
+        Fields (coords, element, b_factor, occupancy) drive the structure factors; fields
+        (chain_id, res_id, res_name, atom_name, altloc_id) carry topology and alignment.
+        res_id round-trips only because atomarray_to_gemmi writes label_seq_id (not just the
+        author seqid), so atomworks' label scheme reads back the real residue numbers instead
+        of collapsing every residue to -1. ins_code is intentionally ignored (see Issue #306).
         """
-        out = tmp_path / "saved.cif"
-        gemmi_structure_from_atomarray.make_mmcif_document().write_file(str(out))
-
-        loaded = load_structure_with_altlocs(out)
         ref = stripped_atom_array
+        save_cif_path = tmp_path / "saved.cif"
+        gemmi_structure = atomarray_to_gemmi(
+            ref, stripped_gemmi.cell, stripped_gemmi.spacegroup_hm
+        )
+        gemmi_structure.make_mmcif_document().write_file(str(save_cif_path))
+        loaded = load_structure_with_altlocs(save_cif_path)
 
         assert len(loaded) == len(ref)
 
-        # topology / matching labels (exact)
-        assert np.array_equal(loaded.chain_id, ref.chain_id)
-        assert np.array_equal(loaded.res_id, ref.res_id)
-        assert set(np.unique(loaded.res_id)) != {-1}  # not collapsed to the degenerate -1
-        assert np.array_equal(loaded.res_name, ref.res_name)
-        assert np.array_equal(loaded.atom_name, ref.atom_name)
+        # Extra fields can exist depending on the structure file. For example, cif vs pdb would
+        # have an extra annotation is_polymer. Here, we specify the key fields we care about.
+        important_annotations = {
+            "chain_id", "res_id", "res_name", "atom_name", "element", "hetero",
+            "b_factor", "occupancy", "altloc_id",
+        }
+        assert important_annotations <= set(ref.get_annotation_categories())
+        assert important_annotations <= set(loaded.get_annotation_categories())
 
-        # scattering-physics fields (element exact; floats within mmCIF write precision)
-        assert np.array_equal(loaded.element, ref.element)
+        # Check altloc ids survive the round-trip
+        assert find_all_altloc_ids(ref)  # sanity: the reference input actually has altlocs
+        blanks = list(BLANK_ALTLOC_IDS)
+        loaded_altloc = np.where(np.isin(loaded.altloc_id, blanks), "", loaded.altloc_id)
+        ref_altloc = np.where(np.isin(ref.altloc_id, blanks), "", ref.altloc_id)
+        assert np.array_equal(loaded_altloc, ref_altloc)
+
+        # Check the non-float annotation columns are identical
+        for category in sorted(important_annotations - {"b_factor", "occupancy", "altloc_id"}):
+            assert np.array_equal(
+                loaded.get_annotation(category), ref.get_annotation(category)
+            ), f"annotation {category!r} did not round-trip"
+
+        assert set(np.unique(loaded.res_id)) != {-1}  # not collapsed to the degenerate -1
         assert len(np.unique(loaded.element)) > 1  # not collapsed to a single/blank symbol
+
+        # Check the coordinates and float annotation are within write precision
         np.testing.assert_allclose(loaded.coord, ref.coord, atol=1e-3)
         np.testing.assert_allclose(loaded.b_factor, ref.b_factor, atol=1e-2)
         np.testing.assert_allclose(loaded.occupancy, ref.occupancy, atol=1e-2)
 
-        # altloc: same id set, and same per-id atom counts
-        assert "altloc_id" in loaded.get_annotation_categories()
-        expected_altloc_ids = find_all_altloc_ids(ref)
-        assert find_all_altloc_ids(loaded) == expected_altloc_ids
-        for altloc_id in expected_altloc_ids:
-            assert np.count_nonzero(loaded.altloc_id == altloc_id) == np.count_nonzero(
-                ref.altloc_id == altloc_id
-            )
-
-    def test_multichain_shared_res_ids_survive_round_trip(self, tmp_path):
-        """Two chains that share res_ids must not be merged across the chain boundary.
-
-        array2hier keyed residue boundaries on res_id alone, so a chain boundary where both
-        sides share a res_id (chains independently numbered from 1) merged the two residues.
-        The direct builder keys on (chain_id, res_id); this guards that.
+    def test_multichain_shared_res_ids_not_merged_in_gemmi(
+        self, multichain_shared_resid_array
+    ):
+        """Test that atomarray_to_gemmi splits shared res_ids into separate residues per chain
+        in the Gemmi Structure object.
         """
-        # Two chains A and B, each with residues 1 and 2 (overlapping numbering).
-        n = 4
-        arr = AtomArray(n)
-        arr.coord = np.arange(n * 3, dtype=np.float32).reshape(n, 3)
-        arr.chain_id = np.array(["A", "A", "B", "B"])
-        arr.res_id = np.array([1, 2, 1, 2])
-        arr.res_name = np.array(["ALA", "GLY", "ALA", "GLY"])
-        arr.atom_name = np.array(["CA", "CA", "CA", "CA"])
-        arr.element = np.array(["C", "C", "C", "C"])
-        arr.set_annotation("b_factor", np.full(n, 20.0))
-        arr.set_annotation("occupancy", np.ones(n))
+        arr = multichain_shared_resid_array
+        model = atomarray_to_gemmi(arr)[0]
 
-        out = tmp_path / "multichain.cif"
-        atomarray_to_gemmi(arr).make_mmcif_document().write_file(str(out))
-        loaded = load_structure_with_altlocs(out)
-
-        assert len(loaded) == n
-        assert np.array_equal(loaded.chain_id, arr.chain_id)
-        assert np.array_equal(loaded.res_id, arr.res_id)
-        # distinct per-atom coords pin identity+order: a boundary merge would drop/reorder atoms
-        np.testing.assert_allclose(loaded.coord, arr.coord, atol=1e-3)
+        chains = list(model)
+        expected_chain_ids = list(dict.fromkeys(arr.chain_id.tolist()))  # unique, input order
+        assert [chain.name for chain in chains] == expected_chain_ids
+        for chain in chains:
+            mask = arr.chain_id == chain.name
+            residues = list(chain)
+            # this fixture is one atom per residue, so per chain the residue seqids and atom
+            # names must equal the chain's atoms one-to-one. A res_id-only merge would fuse
+            # chain A's residue 2 with chain B's residue 2 (shared res_id, adjacent) into one
+            # residue, changing chain A's atom count and dropping chain B's atom -- breaking these.
+            assert [res.seqid.num for res in residues] == arr.res_id[mask].tolist()
+            assert [res.name for res in residues] == arr.res_name[mask].tolist()
+            assert [
+                atom.name for res in residues for atom in res
+            ] == arr.atom_name[mask].tolist()
 
     def test_empty_atom_array_raises(self):
         """An empty AtomArray fails fast rather than yielding a chain-less structure."""


### PR DESCRIPTION
The older PR #272 is broken into 3 smaller PRs for (1) improve synthetic data generation, (2) refactor reward tests, and (3) add structure factor reward. This PR addresses (1).

## Changes relative to main branch
1. Re-implement `atomarray_to_gemmi` to fix the cif→atomarray→gemmi→cif→atomarray… round trip.
2. Write both Fprotein and Ftotal sets into one MTZ with dtype-resolved column selection.
3. Add a helper function`resolve_mtz_column` in `eval/synthetic_utils.py` to support mtz writing and parsing.
4. Bump `sfcalculator-torch` to `>=0.3.3` (0.3.2 computed Ftotal incorrectly); regenerate `pixi.lock`.

## Changes relative to the previous PR #272
Most edits were addressing reviewer comments, except for the reimplementation of `atomarray_to_gemmi` that was not exactly instructed by previous comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Synthetic MTZ generation can now emit both protein-only and total structure-factor columns into a single file when solvent simulation and scaling are enabled.
  * Added consistent per-set amplitude/uncertainty/phase column naming and improved MTZ column selection by data type.
  * Improved atomic structure conversion for preserving chain, residue, altloc, and annotation details.

* **Bug Fixes**
  * Prevented residue IDs shared across chain boundaries from being incorrectly merged.
  * Added validation for empty inputs and ambiguous or invalid MTZ column selections.

* **Tests**
  * Expanded coverage for structure round-tripping, chain/residue handling, empty input errors, and MTZ column resolution logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->