### PR TITLE
fix(rewards): reuse density input preprocessing

### DIFF
--- a/src/sampleworks/core/rewards/real_space_density.py
+++ b/src/sampleworks/core/rewards/real_space_density.py
@@ -18,7 +18,6 @@ from sampleworks.core.forward_models.xray.real_space_density_deps.qfit.volume im
     XMap,
 )
 from sampleworks.utils.elements import elements_to_scattering_indices
-from sampleworks.utils.framework_utils import match_batch
 from sampleworks.utils.torch_utils import try_gpu
 
 
@@ -256,30 +255,9 @@ class RealSpaceRewardFunction:
         return unique_combinations.to(device), inverse_indices.to(device)
 
     def structure_to_reward_input(self, structure: dict) -> dict[str, Float[torch.Tensor, "..."]]:
-        atom_array = structure["asym_unit"]
-        mask = atom_array.occupancy > 0
-        if isinstance(atom_array, AtomArrayStack):
-            atom_array = atom_array[:, mask]
-        else:
-            atom_array = atom_array[mask]
-
-        element_indices = elements_to_scattering_indices(atom_array.element)
-
-        elements = torch.tensor(element_indices, device=self.device, dtype=torch.long).unsqueeze(0)
-        b_factors = torch.from_numpy(atom_array.b_factor).to(self.device).unsqueeze(0)
-        occupancies = torch.from_numpy(atom_array.occupancy).to(self.device).unsqueeze(0)
-
-        coordinates = torch.from_numpy(atom_array.coord).to(self.device)
-        if coordinates.ndim == 2:
-            coordinates = coordinates.unsqueeze(0)
-
-        # AtomArrayStack: coord is (n_models, n_atoms, 3) but annotations are
-        # (n_atoms), so elements/b_factors/occupancies are (1, n_atoms) after
-        # unsqueeze while coordinates is (n_models, n_atoms, 3). Broadcast to match.
-        n_models = coordinates.shape[0]
-        elements = match_batch(elements, target_batch_size=n_models)
-        b_factors = match_batch(b_factors, target_batch_size=n_models)
-        occupancies = match_batch(occupancies, target_batch_size=n_models)
+        coordinates, elements, b_factors, occupancies = extract_density_inputs_from_atomarray(
+            structure["asym_unit"], self.device
+        )
 
         return {
             "coordinates": coordinates,

--- a/src/sampleworks/core/rewards/real_space_density.py
+++ b/src/sampleworks/core/rewards/real_space_density.py
@@ -254,7 +254,9 @@ class RealSpaceRewardFunction:
         unique_combinations, inverse_indices = torch.unique(combined, dim=0, return_inverse=True)
         return unique_combinations.to(device), inverse_indices.to(device)
 
-    def structure_to_reward_input(self, structure: dict) -> dict[str, Float[torch.Tensor, "..."]]:
+    def structure_to_reward_input(
+        self, structure: dict
+    ) -> dict[str, Float[torch.Tensor, "..."] | Int[torch.Tensor, "..."]]:
         coordinates, elements, b_factors, occupancies = extract_density_inputs_from_atomarray(
             structure["asym_unit"], self.device
         )

--- a/tests/rewards/test_real_space_density_reward.py
+++ b/tests/rewards/test_real_space_density_reward.py
@@ -119,11 +119,18 @@ class TestStructureToRewardInput:
         reward_function = RealSpaceRewardFunction.__new__(RealSpaceRewardFunction)
         reward_function.device = device
         inputs = reward_function.structure_to_reward_input({"asym_unit": atom_array})
-        expected = extract_density_inputs_from_atomarray(atom_array, device)
+        expected_coordinates, expected_elements, expected_b_factors, expected_occupancies = (
+            extract_density_inputs_from_atomarray(atom_array, device)
+        )
 
-        for actual, expected_tensor in zip(inputs.values(), expected, strict=True):
-            torch.testing.assert_close(actual, expected_tensor)
-            assert actual.device == device
+        torch.testing.assert_close(inputs["coordinates"], expected_coordinates)
+        torch.testing.assert_close(inputs["elements"], expected_elements)
+        torch.testing.assert_close(inputs["b_factors"], expected_b_factors)
+        torch.testing.assert_close(inputs["occupancies"], expected_occupancies)
+        assert inputs["coordinates"].device == device
+        assert inputs["elements"].device == device
+        assert inputs["b_factors"].device == device
+        assert inputs["occupancies"].device == device
 
         assert inputs["coordinates"].shape == (1, 2, 3)
         assert inputs["coordinates"].dtype == torch.float32
@@ -143,10 +150,14 @@ class TestStructureToRewardInput:
         reward_function = RealSpaceRewardFunction.__new__(RealSpaceRewardFunction)
         reward_function.device = device
         inputs = reward_function.structure_to_reward_input({"asym_unit": atom_array_stack})
-        expected = extract_density_inputs_from_atomarray(atom_array_stack, device)
+        expected_coordinates, expected_elements, expected_b_factors, expected_occupancies = (
+            extract_density_inputs_from_atomarray(atom_array_stack, device)
+        )
 
-        for actual, expected_tensor in zip(inputs.values(), expected, strict=True):
-            torch.testing.assert_close(actual, expected_tensor)
+        torch.testing.assert_close(inputs["coordinates"], expected_coordinates)
+        torch.testing.assert_close(inputs["elements"], expected_elements)
+        torch.testing.assert_close(inputs["b_factors"], expected_b_factors)
+        torch.testing.assert_close(inputs["occupancies"], expected_occupancies)
 
         assert inputs["coordinates"].shape == (2, 1, 3)
         torch.testing.assert_close(inputs["b_factors"], torch.full((2, 1), 20.0, device=device))

--- a/tests/rewards/test_real_space_density_reward.py
+++ b/tests/rewards/test_real_space_density_reward.py
@@ -109,6 +109,49 @@ class TestSetupScatteringParams:
         assert params[0].sum().item() == 0
 
 
+class TestStructureToRewardInput:
+    def test_reuses_density_input_preprocessing(self, atom_array_with_nan_coords, device):
+        """Filter invalid/zero-occupancy atoms and replace valid NaN B-factors."""
+        atom_array = atom_array_with_nan_coords.copy()
+        atom_array.b_factor = np.array([10.0, 15.0, np.nan, 15.0, 40.0])
+        atom_array.occupancy = np.array([1.0, 1.0, 1.0, 1.0, 0.0])
+
+        reward_function = RealSpaceRewardFunction.__new__(RealSpaceRewardFunction)
+        reward_function.device = device
+        inputs = reward_function.structure_to_reward_input({"asym_unit": atom_array})
+        expected = extract_density_inputs_from_atomarray(atom_array, device)
+
+        for actual, expected_tensor in zip(inputs.values(), expected, strict=True):
+            torch.testing.assert_close(actual, expected_tensor)
+            assert actual.device == device
+
+        assert inputs["coordinates"].shape == (1, 2, 3)
+        assert inputs["coordinates"].dtype == torch.float32
+        assert inputs["elements"].dtype == torch.long
+        assert inputs["b_factors"].dtype == torch.float32
+        assert inputs["occupancies"].dtype == torch.float32
+        torch.testing.assert_close(inputs["b_factors"], torch.tensor([[10.0, 20.0]], device=device))
+
+    def test_matches_extractor_batching_for_atom_array_stacks(
+        self, atom_array_stack_with_nan_coords, device
+    ):
+        """Keep extractor batching semantics for multi-model inputs."""
+        atom_array_stack = atom_array_stack_with_nan_coords.copy()
+        atom_array_stack.b_factor = np.array([np.nan, 20.0, 20.0])
+        atom_array_stack.occupancy = np.array([0.5, 0.5, 0.0])
+
+        reward_function = RealSpaceRewardFunction.__new__(RealSpaceRewardFunction)
+        reward_function.device = device
+        inputs = reward_function.structure_to_reward_input({"asym_unit": atom_array_stack})
+        expected = extract_density_inputs_from_atomarray(atom_array_stack, device)
+
+        for actual, expected_tensor in zip(inputs.values(), expected, strict=True):
+            torch.testing.assert_close(actual, expected_tensor)
+
+        assert inputs["coordinates"].shape == (2, 1, 3)
+        torch.testing.assert_close(inputs["b_factors"], torch.full((2, 1), 20.0, device=device))
+
+
 @pytest.mark.gpu
 @pytest.mark.slow
 class TestRewardFunctionBasics:


### PR DESCRIPTION
## Summary
- delegate reward input preparation to the shared density extractor
- cover invalid coordinates, NaN B-factors, zero occupancy, and stack batching

## Tests
- uv run --with setuptools pytest tests/rewards/test_real_space_density_reward.py::TestStructureToRewardInput tests/utils/test_density_utils.py::TestExtractDensityInputsFromAtomArrayStack
- uv run ruff check .
- uv run ruff format --check .
- uv run ty check src/sampleworks/core/rewards/real_space_density.py tests/rewards/test_real_space_density_reward.py

Closes #314