### PR TITLE
refactor(synthetic): move generation out of eval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ src/sampleworks/
 ├── models/                # Generative model wrappers (Boltz, Protenix, RF3)
 ├── metrics/               # Quality metrics (LDDT, sidechain)
 ├── eval/                  # Evaluation utilities
+├── synthetic/             # Synthetic data generation
 ├── data/                  # Reference data (protein configs)
 ├── runs/                  # `sampleworks-runs` CLI + TOML preset orchestrator
 └── utils/                 # Shared utilities

--- a/scripts/eval/classify_altloc_regions.py
+++ b/scripts/eval/classify_altloc_regions.py
@@ -51,18 +51,16 @@ import pandas as pd
 from biotite.structure import AtomArray, AtomArrayStack
 from loguru import logger
 from sampleworks.eval.grid_search_eval_utils import resolve_cif_path
-from sampleworks.eval.structure_utils import (
-    ATOMWORKS_COMPARISON_OPS,
-    get_mask_from_old_selection_string,
-    parse_selection_string,
-)
 from sampleworks.metrics.lddt import AllAtomLDDT
 from sampleworks.utils.atom_array_utils import (
+    ATOMWORKS_COMPARISON_OPS,
     BACKBONE_ATOM_TYPES,
     BLANK_ALTLOC_IDS,
     build_pairwise_altloc_arrays,
     detect_altlocs,
+    get_mask_from_old_selection_string,
     load_structure_with_altlocs,
+    parse_selection_string,
 )
 
 

--- a/src/sampleworks/eval/generate_synthetic_density.py
+++ b/src/sampleworks/eval/generate_synthetic_density.py
@@ -9,7 +9,7 @@ from typing import ClassVar
 import torch
 from loguru import logger
 from sampleworks.core.forward_models.xray.real_space_density import XMap_torch
-from sampleworks.eval.synthetic_utils import (
+from sampleworks.synthetic.synthetic_utils import (
     load_structure_for_synthetic_reward,
     resolve_parallel_jobs,
     validate_occupancy_values,

--- a/src/sampleworks/eval/structure_utils.py
+++ b/src/sampleworks/eval/structure_utils.py
@@ -1,9 +1,8 @@
-import re
 import traceback
 from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any, cast, overload
+from typing import cast, overload
 
 import numpy as np
 import torch
@@ -13,12 +12,11 @@ from loguru import logger
 from sampleworks.core.rewards.protocol import RewardInputs
 from sampleworks.eval.eval_dataclasses import ProteinConfig
 from sampleworks.models.protocol import GenerativeModelInput
+from sampleworks.utils import atom_array_utils
 from sampleworks.utils.atom_array_utils import load_structure_with_altlocs
 from sampleworks.utils.atom_reconciler import AtomReconciler
 from sampleworks.utils.framework_utils import match_batch
 
-
-ATOMWORKS_COMPARISON_OPS = ("==", ">", "<", "<=", ">=", " in ")
 
 try:
     from sampleworks.models.protenix.structure_processing import (
@@ -243,114 +241,19 @@ def process_structure_to_trajectory_input(
     )
 
 
-# TODO: migrate this to atomworks's selection algebra that is added to AtomArray/Stack
-#   https://github.com/diff-use/sampleworks/issues/56
-def parse_selection_string(selection: str) -> tuple[str | None, int | None, int | None]:
-    """Parse a selection string like 'chain A and resi 326-339'.
-
-    Supports both residue ranges ('resi 10-50') and single residues ('resi 10').
-    For single residues, resi_start and resi_end will be equal.
-
-    Parameters
-    ----------
-    selection : str
-        Selection string (e.g., 'chain A', 'resi 10', 'chain A and resi 10-50')
-
-    Returns
-    -------
-    tuple
-        (chain_id, resi_start, resi_end) - any component may be None if not specified
-    """
-    # Parse "chain X and resi N-M" format and generalizations of that.
-    chain = re.search(r"chain\s+(\w+)", selection, re.IGNORECASE)
-    if chain is not None:
-        chain = chain.group(1).upper()
-
-    residues = re.search(r"resi\s+(\d+)(?:-(\d+))?", selection, re.IGNORECASE)
-    if residues is not None:
-        resi_start = int(residues.group(1))
-        resi_end = int(residues.group(2)) if residues.group(2) else resi_start
-    else:
-        resi_start = resi_end = None
-
-    if chain is None and resi_start is None and resi_end is None:
-        logger.warning(
-            "Selection string did not match any known patterns (e.g. 'chain A', 'resi 10-50')"
-        )
-
-    return chain, resi_start, resi_end
-
-
-def apply_selection(atom_array: AtomArray, selection: str | None) -> AtomArray:
-    """Apply an atom selection string to filter a structure.
-
-    Parameters
-    ----------
-    atom_array
-        Structure to filter
-    selection
-        Selection string (e.g., 'chain A and resi 10-50'). If None, returns
-        the entire structure unchanged.
-
-    Returns
-    -------
-    AtomArray
-        Filtered structure containing only atoms matching the selection
-
-    Raises
-    ------
-    ValueError
-        If the selection string matches no atoms
-    """
-    if selection is None:
-        return atom_array
-
-    if not any(x in selection for x in ATOMWORKS_COMPARISON_OPS):
-        mask = get_mask_from_old_selection_string(atom_array, selection)
-    else:
-        mask = atom_array.mask(selection)
-
-    return cast(AtomArray, atom_array[mask])
-
-
-def get_mask_from_old_selection_string(
-    atom_array: AtomArray | AtomArrayStack, selection: str
-) -> np.ndarray[tuple[int], np.dtype[Any]]:
-    DeprecationWarning(
-        f"Using old-style selection strings like {selection} is deprecated."
-        f" Use atomworks/pandas style selection strings instead."
-    )
-    chain_id, resi_start, resi_end = parse_selection_string(selection)
-    # use the length of any of the required non-coord attributes to get the mask shape
-    mask = np.ones(len(atom_array.res_id), dtype=bool)
-
-    if chain_id is not None:
-        mask &= atom_array.chain_id == chain_id
-
-    if resi_start is not None:
-        res_ids = cast(np.ndarray, atom_array.res_id)
-        if resi_end is not None:
-            mask &= (res_ids >= resi_start) & (res_ids <= resi_end)
-        else:
-            mask &= res_ids == resi_start
-
-    if mask.sum() == 0:
-        raise ValueError(f"Selection '{selection}' matched no atoms")
-    return mask
-
-
 def selection_to_residues(atom_array: AtomArray, selection: str) -> set[tuple[str, int]]:
     """Return the ``(chain_id, res_id)`` pairs covered by *selection*.
 
     Accepts both legacy ``chain X and resi a-b`` strings and atomworks-style
-    selections (``==``, ``or``, ``in``, ...) by delegating to :func:`apply_selection`,
-    so callers can treat every selection syntax uniformly. Returns an empty set
-    when the selection matches no atoms.
+    selections (``==``, ``or``, ``in``, ...) by delegating to
+    :func:`sampleworks.utils.atom_array_utils.apply_selection`, so callers can
+    treat every selection syntax uniformly. Returns an empty set when the
+    selection matches no atoms.
 
     TODO: make this work with ligands more robustly!
     """
     try:
-        selected = apply_selection(atom_array, selection)
+        selected = atom_array_utils.apply_selection(atom_array, selection)
     except ValueError:
         return set()
     if selected.array_length() == 0:
@@ -387,8 +290,8 @@ def extract_selection_coordinates(
     else:
         working_array = atom_array
 
-    if not any(x in selection for x in ATOMWORKS_COMPARISON_OPS):
-        mask = get_mask_from_old_selection_string(atom_array, selection)
+    if not any(x in selection for x in atom_array_utils.ATOMWORKS_COMPARISON_OPS):
+        mask = atom_array_utils.get_mask_from_old_selection_string(atom_array, selection)
     else:
         mask = working_array.mask(selection)
 

--- a/src/sampleworks/synthetic/__init__.py
+++ b/src/sampleworks/synthetic/__init__.py
@@ -1,0 +1,1 @@
+"""Synthetic data-generation utilities."""

--- a/src/sampleworks/synthetic/generate_synthetic_sf.py
+++ b/src/sampleworks/synthetic/generate_synthetic_sf.py
@@ -21,15 +21,16 @@ import reciprocalspaceship.utils
 import torch
 from biotite.structure import AtomArray
 from loguru import logger
-from sampleworks.eval.synthetic_utils import (
+from SFC_Torch import SFcalculator
+from SFC_Torch.io import array2hier, PDBParser
+
+from sampleworks.synthetic.synthetic_utils import (
     load_structure_for_synthetic_reward,
     resolve_parallel_jobs,
     validate_occupancy_values,
 )
 from sampleworks.utils.atom_array_utils import BLANK_ALTLOC_IDS
 from sampleworks.utils.torch_utils import try_gpu
-from SFC_Torch import SFcalculator
-from SFC_Torch.io import array2hier, PDBParser
 
 
 @dataclass

--- a/src/sampleworks/synthetic/synthetic_utils.py
+++ b/src/sampleworks/synthetic/synthetic_utils.py
@@ -1,4 +1,4 @@
-"""Shared utilities for synthetic structure factor and density generation."""
+"""Shared utilities for synthetic structure-factor and density generation."""
 
 import math
 import traceback
@@ -8,6 +8,7 @@ import torch
 from atomworks.io.transforms.atom_array import remove_waters
 from biotite.structure import AtomArray
 from loguru import logger
+
 from sampleworks.eval.structure_utils import apply_selection
 from sampleworks.utils.atom_array_utils import (
     AltlocInfo,

--- a/src/sampleworks/synthetic/synthetic_utils.py
+++ b/src/sampleworks/synthetic/synthetic_utils.py
@@ -9,9 +9,9 @@ from atomworks.io.transforms.atom_array import remove_waters
 from biotite.structure import AtomArray
 from loguru import logger
 
-from sampleworks.eval.structure_utils import apply_selection
 from sampleworks.utils.atom_array_utils import (
     AltlocInfo,
+    apply_selection,
     detect_altlocs,
     keep_amino_acids,
     keep_polymer,

--- a/src/sampleworks/utils/atom_array_utils.py
+++ b/src/sampleworks/utils/atom_array_utils.py
@@ -1,3 +1,4 @@
+import re
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
@@ -14,6 +15,7 @@ from loguru import logger
 
 BACKBONE_ATOM_TYPES = ["C", "CA", "N", "O"]
 BLANK_ALTLOC_IDS = {"", ".", " ", "?"}
+ATOMWORKS_COMPARISON_OPS = ("==", ">", "<", "<=", ">=", " in ")
 
 
 @dataclass
@@ -31,6 +33,103 @@ class AltlocInfo:
 
     altloc_ids: list[str]
     atom_masks: dict[str, np.ndarray[Any, np.dtype[np.bool_]]]
+
+
+# TODO: migrate this to atomworks's selection algebra that is added to AtomArray/Stack
+#   https://github.com/diff-use/sampleworks/issues/56
+def parse_selection_string(selection: str) -> tuple[str | None, int | None, int | None]:
+    """Parse a selection string like 'chain A and resi 326-339'.
+
+    Supports both residue ranges ('resi 10-50') and single residues ('resi 10').
+    For single residues, resi_start and resi_end will be equal.
+
+    Parameters
+    ----------
+    selection : str
+        Selection string (e.g., 'chain A', 'resi 10', 'chain A and resi 10-50')
+
+    Returns
+    -------
+    tuple
+        (chain_id, resi_start, resi_end) - any component may be None if not specified
+    """
+    # Parse "chain X and resi N-M" format and generalizations of that.
+    chain = re.search(r"chain\s+(\w+)", selection, re.IGNORECASE)
+    if chain is not None:
+        chain = chain.group(1).upper()
+
+    residues = re.search(r"resi\s+(\d+)(?:-(\d+))?", selection, re.IGNORECASE)
+    if residues is not None:
+        resi_start = int(residues.group(1))
+        resi_end = int(residues.group(2)) if residues.group(2) else resi_start
+    else:
+        resi_start = resi_end = None
+
+    if chain is None and resi_start is None and resi_end is None:
+        logger.warning(
+            "Selection string did not match any known patterns (e.g. 'chain A', 'resi 10-50')"
+        )
+
+    return chain, resi_start, resi_end
+
+
+def apply_selection(atom_array: AtomArray, selection: str | None) -> AtomArray:
+    """Apply an atom selection string to filter a structure.
+
+    Parameters
+    ----------
+    atom_array
+        Structure to filter
+    selection
+        Selection string (e.g., 'chain A and resi 10-50'). If None, returns
+        the entire structure unchanged.
+
+    Returns
+    -------
+    AtomArray
+        Filtered structure containing only atoms matching the selection
+
+    Raises
+    ------
+    ValueError
+        If the selection string matches no atoms
+    """
+    if selection is None:
+        return atom_array
+
+    if not any(x in selection for x in ATOMWORKS_COMPARISON_OPS):
+        mask = get_mask_from_old_selection_string(atom_array, selection)
+    else:
+        mask = atom_array.mask(selection)
+
+    return cast(AtomArray, atom_array[mask])
+
+
+def get_mask_from_old_selection_string(
+    atom_array: AtomArray | AtomArrayStack, selection: str
+) -> np.ndarray[tuple[int], np.dtype[Any]]:
+    """Build an atom mask from a legacy chain and residue selection string."""
+    DeprecationWarning(
+        f"Using old-style selection strings like {selection} is deprecated."
+        f" Use atomworks/pandas style selection strings instead."
+    )
+    chain_id, resi_start, resi_end = parse_selection_string(selection)
+    # use the length of any of the required non-coord attributes to get the mask shape
+    mask = np.ones(len(atom_array.res_id), dtype=bool)
+
+    if chain_id is not None:
+        mask &= atom_array.chain_id == chain_id
+
+    if resi_start is not None:
+        res_ids = cast(np.ndarray, atom_array.res_id)
+        if resi_end is not None:
+            mask &= (res_ids >= resi_start) & (res_ids <= resi_end)
+        else:
+            mask &= res_ids == resi_start
+
+    if mask.sum() == 0:
+        raise ValueError(f"Selection '{selection}' matched no atoms")
+    return mask
 
 
 def load_structure_with_altlocs(path: Path) -> AtomArray:

--- a/tests/eval/test_structure_utils.py
+++ b/tests/eval/test_structure_utils.py
@@ -17,9 +17,9 @@ from sampleworks.eval.structure_utils import (
 )
 from sampleworks.utils.atom_array_utils import (
     apply_selection,
+    map_altlocs_to_stack,
     parse_selection_string,
 )
-from sampleworks.utils.atom_array_utils import map_altlocs_to_stack
 
 
 @pytest.fixture

--- a/tests/eval/test_structure_utils.py
+++ b/tests/eval/test_structure_utils.py
@@ -8,11 +8,13 @@ import pytest
 from biotite.structure import AtomArray, AtomArrayStack
 from sampleworks.eval.eval_dataclasses import ProteinConfig
 from sampleworks.eval.structure_utils import (
-    apply_selection,
     extract_selection_coordinates,
     get_asym_unit_from_structure,
     get_reference_atomarraystack,
     get_reference_structure_coords,
+)
+from sampleworks.utils.atom_array_utils import (
+    apply_selection,
     parse_selection_string,
 )
 

--- a/tests/synthetic/test_generate_synthetic_sf.py
+++ b/tests/synthetic/test_generate_synthetic_sf.py
@@ -9,8 +9,8 @@ import pytest
 import torch
 from atomworks.io.transforms.atom_array import remove_waters
 from biotite.structure import AtomArray
-from sampleworks.eval.generate_synthetic_sf import atomarray_to_gemmi
-from sampleworks.eval.synthetic_utils import assign_occupancies
+from sampleworks.synthetic.generate_synthetic_sf import atomarray_to_gemmi
+from sampleworks.synthetic.synthetic_utils import assign_occupancies
 from sampleworks.utils.atom_array_utils import (
     detect_altlocs,
     keep_amino_acids,

--- a/tests/synthetic/test_synthetic_utils.py
+++ b/tests/synthetic/test_synthetic_utils.py
@@ -2,7 +2,7 @@
 
 import pytest
 import torch
-from sampleworks.eval.synthetic_utils import resolve_parallel_jobs
+from sampleworks.synthetic.synthetic_utils import resolve_parallel_jobs
 
 
 @pytest.mark.parametrize("n_jobs", [-2, -1, 2, 8])


### PR DESCRIPTION
## Summary
- Move shared synthetic utilities and structure-factor generation into `sampleworks.synthetic`.
- Keep evaluation-only density generation under `sampleworks.eval` and update its shared utility import.
- Relocate synthetic tests and document the package layout.

## Testing
- `uv run --with setuptools pytest tests/synthetic tests/eval/test_generate_synthetic_density.py`
- `uv run ruff check src/sampleworks/synthetic src/sampleworks/eval/generate_synthetic_density.py tests/synthetic tests/eval/test_generate_synthetic_density.py`
- `uv run ruff format --check src/sampleworks/synthetic src/sampleworks/eval/generate_synthetic_density.py tests/synthetic tests/eval/test_generate_synthetic_density.py`
- `uv run ty check src/sampleworks/synthetic src/sampleworks/eval/generate_synthetic_density.py tests/synthetic tests/eval/test_generate_synthetic_density.py`

Closes #312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shared atom-selection support for both modern comparison expressions and legacy chain/residue filters.
  - Legacy selection strings now provide validation and deprecation warnings.

- **Refactor**
  - Consolidated synthetic data-generation utilities into the synthetic utilities package.
  - Updated structure evaluation and synthetic workflows to use shared selection handling.

- **Documentation**
  - Documented the synthetic utilities package and added it to the project module layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->