### PR TITLE
ci: pin pixi-version in setup-pixi for deterministic lock validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Install pixi
         uses: prefix-dev/setup-pixi@v0.8.8
         with:
+          pixi-version: v0.73.0
           environments: boltz-dev
 
       - name: Ruff lint
@@ -79,6 +80,7 @@ jobs:
       - name: Install pixi
         uses: prefix-dev/setup-pixi@v0.8.8
         with:
+          pixi-version: v0.73.0
           environments: ${{ matrix.environment }}
 
       - name: Run ty
@@ -103,6 +105,7 @@ jobs:
       - name: Install pixi
         uses: prefix-dev/setup-pixi@v0.8.8
         with:
+          pixi-version: v0.73.0
           environments: ${{ matrix.environment }}
 
       - name: Run CPU tests

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Install pixi
         uses: prefix-dev/setup-pixi@19eac09b398e3d0c747adc7921926a6d802df4da # v0.8.8
         with:
+          pixi-version: v0.73.0
           cache: false  # NFS-backed cache on self-hosted runner handles this
 
       - name: Build CUDA extensions

--- a/.github/workflows/relock.yml
+++ b/.github/workflows/relock.yml
@@ -1,0 +1,43 @@
+name: Relock
+
+# Regenerate pixi.lock on Linux and commit it back to the dispatched branch.
+# The workspace pins system-requirements.cuda and uses git/editable deps, so a
+# from-scratch solve must build them for linux-64 — which cannot be done on
+# macOS. Run this workflow (Actions tab -> Relock -> Run workflow, pick the
+# branch) whenever pyproject.toml changes and the lock needs refreshing.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  relock:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Install pixi
+        uses: prefix-dev/setup-pixi@v0.8.8
+        with:
+          pixi-version: v0.73.0
+          run-install: false
+
+      - name: Regenerate lockfile
+        run: pixi lock
+
+      - name: Commit lockfile if changed
+        run: |
+          if git diff --quiet -- pixi.lock; then
+            echo "pixi.lock already up to date; nothing to commit."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add pixi.lock
+            git commit -m "chore: relock pixi.lock on linux (pixi v0.73.0)"
+            git push origin HEAD:${{ github.ref_name }}
+          fi


### PR DESCRIPTION
## Problem

CI validates the lockfile with `pixi install --locked` (strict — it fails rather than re-solving if `pixi.lock` doesn't match `pyproject.toml`). But `setup-pixi@v0.8.8` pins the *action*, not the pixi *binary* — it installs whatever pixi is "latest" at run time.

So the pixi that generates a lock locally can differ from the pixi that validates it in CI, and two versions can disagree on the manifest hash. The symptom is intermittent `lock file not up-to-date with the workspace` failures on PRs that didn't touch dependencies (seen on #300), and CI that can start failing with no code change when a new pixi ships.

## Fix

Pin `pixi-version: v0.73.0` on every `setup-pixi` step (ci.yml x3, gpu-tests.yml). v0.73.0 is the version that generated the current green lock on `main`. Lock validation is now deterministic and matches the committed lock's generator.

## Follow-up

Contributors regenerating the lock should use the same pinned pixi (`pixi self-update --version 0.73.0` or install that version), run `pixi lock`, and commit `pyproject.toml` + `pixi.lock` together. Bumping pixi later is a one-line change here plus a relock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the Pixi toolchain version used by automated linting, type checks, CPU tests, and GPU tests.
  * Improved consistency and reproducibility across continuous integration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->