### PR TITLE
Split checkpoints into per-file layers for parallel cold pulls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ FROM ${CHECKPOINTS_IMAGE} AS checkpoints
 # ============================================================================
 FROM source AS pixi-envs
 
-# Checkpoints (~10 GB) rarely change, so this layer stays cacheable across most
+# Checkpoints (~10 GB) rarely change, so these layers stay cacheable across most
 # source edits and dependency-only rebuilds.
 #
 # Split per-file so a cold pull fetches them as concurrent S3 flows instead of
@@ -99,15 +99,30 @@ FROM source AS pixi-envs
 # containerd downloads each layer on its own connection (up to
 # max_concurrent_downloads), so N layers pull in parallel where one COPY could
 # not. The files are near-incompressible weights, so extra layer boundaries add
-# essentially no image size. The trailing catch-all ships any checkpoint added
-# or renamed later that is not enumerated above (unsplit, but never dropped).
-COPY --from=checkpoints /checkpoints/boltz1_conf.ckpt               /checkpoints/
-COPY --from=checkpoints /checkpoints/rf3_foundry_01_24_latest.ckpt  /checkpoints/
-COPY --from=checkpoints /checkpoints/boltz2_conf.ckpt              /checkpoints/
+# essentially no image size. Largest first: the pull finishes with the slowest
+# layer, so the biggest checkpoint should start downloading first.
+#
+# Do NOT add a trailing catch-all `COPY /checkpoints/ /checkpoints/`. Layers are
+# deduplicated per layer, not per file, so re-copying files already present
+# writes a second full ~10 GB copy of every checkpoint AND reinstates the single
+# serial flow this split exists to remove. The guard below covers new
+# checkpoints instead, by failing the build rather than shipping them silently.
+COPY --from=checkpoints /checkpoints/boltz1_conf.ckpt                /checkpoints/
+COPY --from=checkpoints /checkpoints/rf3_foundry_01_24_latest.ckpt   /checkpoints/
+COPY --from=checkpoints /checkpoints/boltz2_conf.ckpt                /checkpoints/
 COPY --from=checkpoints /checkpoints/protenix_base_default_v0.5.0.pt /checkpoints/
-COPY --from=checkpoints /checkpoints/ccd.pkl                       /checkpoints/
-COPY --from=checkpoints /checkpoints/mols/                         /checkpoints/mols/
-COPY --from=checkpoints /checkpoints/                              /checkpoints/
+COPY --from=checkpoints /checkpoints/ccd.pkl                         /checkpoints/
+COPY --from=checkpoints /checkpoints/mols/                           /checkpoints/mols/
+
+# Bind mount reads the checkpoint stage without copying any bytes into the
+# image. Keep this list in sync with the COPY lines above; bumping
+# CHECKPOINTS_SOURCE_IMAGE to a digest with new or renamed files fails here.
+RUN --mount=type=bind,from=checkpoints,target=/ck \
+    unexpected="$(ls -A /ck/checkpoints | grep -vxE 'boltz1_conf\.ckpt|boltz2_conf\.ckpt|ccd\.pkl|rf3_foundry_01_24_latest\.ckpt|protenix_base_default_v0\.5\.0\.pt|mols')"; \
+    [ -z "${unexpected}" ] || { \
+        echo "Unenumerated checkpoints, add a COPY line above for each: ${unexpected}"; \
+        exit 1; \
+    }
 
 # IMPORTANT: keep these installs in a single RUN. Splitting them into separate
 # Docker layers duplicates shared conda packages (numpy, CUDA libs, etc.) and can

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,21 @@ FROM source AS pixi-envs
 
 # Checkpoints (~10 GB) rarely change, so this layer stays cacheable across most
 # source edits and dependency-only rebuilds.
-COPY --from=checkpoints /checkpoints/ /checkpoints/
+#
+# Split per-file so a cold pull fetches them as concurrent S3 flows instead of
+# one serial ~10 GB stream. Harbor redirects each blob GET to presigned S3, and
+# containerd downloads each layer on its own connection (up to
+# max_concurrent_downloads), so N layers pull in parallel where one COPY could
+# not. The files are near-incompressible weights, so extra layer boundaries add
+# essentially no image size. The trailing catch-all ships any checkpoint added
+# or renamed later that is not enumerated above (unsplit, but never dropped).
+COPY --from=checkpoints /checkpoints/boltz1_conf.ckpt               /checkpoints/
+COPY --from=checkpoints /checkpoints/rf3_foundry_01_24_latest.ckpt  /checkpoints/
+COPY --from=checkpoints /checkpoints/boltz2_conf.ckpt              /checkpoints/
+COPY --from=checkpoints /checkpoints/protenix_base_default_v0.5.0.pt /checkpoints/
+COPY --from=checkpoints /checkpoints/ccd.pkl                       /checkpoints/
+COPY --from=checkpoints /checkpoints/mols/                         /checkpoints/mols/
+COPY --from=checkpoints /checkpoints/                              /checkpoints/
 
 # IMPORTANT: keep these installs in a single RUN. Splitting them into separate
 # Docker layers duplicates shared conda packages (numpy, CUDA libs, etc.) and can


### PR DESCRIPTION
Splits the single ~10 GB `COPY --from=checkpoints /checkpoints/` into per-file layers so a cold image pull downloads them as concurrent S3 flows instead of one serial stream.

## Why

Investigating ENG-443 (workspace pods stuck in `ContainerCreating` for 10+ min on cold nodes), the root cause turned out to be the image-pull path, not the cluster network:

- Harbor redirects every blob GET to a presigned URL on S3 (`astera-sh-harbor-registry.s3.us-west-1.amazonaws.com`).
- containerd downloads each layer on its own connection, and a single flow to S3 measures ~74 MB/s.
- The checkpoints are **one** layer = **one** flow = ~10.1 GB (70% of the 14.4 GB compressed pull) over ~137 s serial.

Measured on live nodes: 4 parallel S3 flows aggregate ~247 MB/s (~3.3x). The checkpoint files are evenly sized (largest is `boltz1_conf.ckpt` at 3.6 GB of 10.1 GB), so splitting per file and pulling concurrently drops the checkpoint portion from ~137 s to ~50 s (bounded by the largest file).

## What

Enumerate the checkpoints as six separate `COPY --from=checkpoints` layers, ordered largest first so the longest download starts earliest. Weights are near-incompressible, so the extra layer boundaries add no meaningful image size. Layer order is unchanged relative to the `pixi install` step, so build caching is preserved.

A checkpoint that exists in the source image but is not enumerated would be silently dropped from the build, so a bind-mounted guard fails the build and names the missing files. The bind mount reads the checkpoint stage without copying any bytes into the image, so the guard layer is 0 B.

## Notes

- Warm pulls via the in-cluster Spegel P2P cache (~660 MB/s) are already fast and unaffected; this targets the first-puller / freshly-pushed-digest case.
- To realize the full parallelism, GPU nodes need containerd `max_concurrent_downloads` raised to cover the number of checkpoint layers (default is 3). That is a cluster-side change handled separately in the astera-k3s repo; this PR is the build-time half and is safe to merge independently. Even at the default of 3, three concurrent flows still beat one.
- Bumping `CHECKPOINTS_SOURCE_IMAGE` to a digest with new or renamed checkpoints now fails the build rather than shipping a partial image. Renames fail at the `COPY` itself, additions fail at the guard.
- Validated with `docker buildx build --call check` (no warnings), plus a synthetic checkpoint image reproducing the real filenames: six split layers with a 0 B guard, no duplicated bytes, and confirmed build failure on both an added and a renamed checkpoint.

### Revision note

An earlier revision of this branch ended the block with a catch-all `COPY --from=checkpoints /checkpoints/ /checkpoints/` intended to ship unenumerated checkpoints. That was wrong and is removed. Docker deduplicates per layer, not per file, so re-copying files already present wrote a second full ~10 GB copy of every checkpoint (measured: 324 MB vs 164 MB on a scaled-down reproduction) and reinstated the single serial flow this PR exists to remove, making cold pulls slower than `main`. The guard replaces it.

Ref: ENG-443
