### PR TITLE
fix(grid-search): run protpardelle jobs in their pixi env

### DIFF
--- a/run_grid_search.py
+++ b/run_grid_search.py
@@ -224,6 +224,25 @@ def build_args_for_process_pool(
     return guidance_config
 
 
+def worker_log_path_for(job_queue_path: str) -> str:
+    """Return the path a worker redirects its subprocess output to.
+
+    Derived in one place so the collector's error messages always name the
+    file ``run_guidance_queue_script`` actually wrote.
+
+    Parameters
+    ----------
+    job_queue_path : str
+        Path to the worker's pickled job queue.
+
+    Returns
+    -------
+    str
+        Sibling ``.log`` path for that worker's subprocess output.
+    """
+    return job_queue_path.replace(".pkl", ".log")
+
+
 def run_grid_search(
     jobs: list[JobConfig],
     gpus: list[str],
@@ -302,7 +321,9 @@ def run_grid_search(
 
         for completed in concurrent.futures.as_completed(futures):  # ty: ignore
             job_queue_path = futures[completed]
-            worker_log_path = job_queue_path.replace(".pkl", ".log")
+            # Same file the worker redirects its subprocess output to; these
+            # messages exist to point the reader at it.
+            worker_log_path = worker_log_path_for(job_queue_path)
             # The worker raises before it can write results, so surface its
             # traceback here rather than reporting the missing results file.
             worker_error = completed.exception()
@@ -400,7 +421,7 @@ def run_guidance_queue_script(
         f"(selected GPU {requested_gpu} via {gpu_source})"
     )
 
-    with open(job_queue_path.replace(".pkl", ".log"), "w") as log_file:
+    with open(worker_log_path_for(job_queue_path), "w") as log_file:
         result = subprocess.run(
             cmd,
             stdout=log_file,

--- a/run_grid_search.py
+++ b/run_grid_search.py
@@ -159,17 +159,41 @@ def detect_gpus() -> list[str]:
     return ["0"]
 
 
+# Every StructurePredictor must appear here; a missing entry only fails inside the
+# worker subprocess, long after the grid has been generated.
+MODEL_PIXI_ENVS: dict[StructurePredictor, str] = {
+    StructurePredictor.BOLTZ_1: "boltz",
+    StructurePredictor.BOLTZ_2: "boltz",
+    StructurePredictor.PROTENIX: "protenix",
+    StructurePredictor.RF3: "rf3",
+    StructurePredictor.PROTPARDELLE: "protpardelle",
+}
+
+
 def get_pixi_env(model: str) -> str:
-    """Return the pixi environment name needed to run a model family."""
-    if model in (StructurePredictor.BOLTZ_1, StructurePredictor.BOLTZ_2):
-        return "boltz"
-    elif model == StructurePredictor.PROTENIX:
-        return "protenix"
-    elif model == StructurePredictor.RF3:
-        return "rf3"
-    else:
-        valid_options = [m.value for m in StructurePredictor]
-        raise ValueError(f"Unknown model: {model}. Valid options are: {valid_options}")
+    """Return the pixi environment name needed to run a model family.
+
+    Parameters
+    ----------
+    model : str
+        Structure predictor name, e.g. ``boltz2`` or ``protpardelle``.
+
+    Returns
+    -------
+    str
+        Pixi environment name that provides the model's dependencies.
+
+    Raises
+    ------
+    ValueError
+        If the model is not a known ``StructurePredictor`` or has no mapped
+        pixi environment.
+    """
+    try:
+        return MODEL_PIXI_ENVS[StructurePredictor(model)]
+    except (ValueError, KeyError):
+        valid_options = [m.value for m in MODEL_PIXI_ENVS]
+        raise ValueError(f"Unknown model: {model}. Valid options are: {valid_options}") from None
 
 
 def build_args_for_process_pool(
@@ -277,27 +301,48 @@ def run_grid_search(
             futures[future] = job_queue_path
 
         for completed in concurrent.futures.as_completed(futures):  # ty: ignore
-            try:
-                with open(futures[completed].replace(".pkl", ".results.pkl"), "rb") as f:
-                    result = pickle.load(f)
+            job_queue_path = futures[completed]
+            worker_log_path = job_queue_path.replace(".pkl", ".log")
+            # The worker raises before it can write results, so surface its
+            # traceback here rather than reporting the missing results file.
+            worker_error = completed.exception()
+            if worker_error is not None:
+                failed += 1
+                log.opt(exception=worker_error).error(
+                    f"Worker for {job_queue_path} raised before writing results"
+                )
+                continue
 
-                results.extend(result)
-                for r in result:
-                    if r.status == "success":
-                        successful += 1
-                        log.info(
-                            f"SUCCESS ({r.protein}, {r.model_name}, {r.method}, {r.scaler} "
-                            f"{r.runtime_seconds:.1f}s): {r.log_path}"
-                        )
-                    else:
-                        failed += 1
-                        log.error(
-                            f"FAILED ({r.protein}, {r.model_name}, {r.method}, {r.scaler} "
-                            f"exit={r.exit_code}): {r.log_path}"
-                        )
+            process_result = completed.result()
+            if process_result.returncode != 0:
+                log.error(
+                    f"Worker for {job_queue_path} exited with code "
+                    f"{process_result.returncode}; see {worker_log_path}"
+                )
+
+            try:
+                with open(job_queue_path.replace(".pkl", ".results.pkl"), "rb") as f:
+                    result = pickle.load(f)
             except Exception as e:
                 failed += 1
-                log.error(f"Job failed with exception: {e}")  # this won't be very informative
+                log.error(f"Could not read results for {job_queue_path}: {e}")
+                log.error(f"Worker subprocess output, if any, is in {worker_log_path}")
+                continue
+
+            results.extend(result)
+            for r in result:
+                if r.status == "success":
+                    successful += 1
+                    log.info(
+                        f"SUCCESS ({r.protein}, {r.model_name}, {r.method}, {r.scaler} "
+                        f"{r.runtime_seconds:.1f}s): {r.log_path}"
+                    )
+                else:
+                    failed += 1
+                    log.error(
+                        f"FAILED ({r.protein}, {r.model_name}, {r.method}, {r.scaler} "
+                        f"exit={r.exit_code}): {r.log_path}"
+                    )
     return results
 
 

--- a/tests/test_run_grid_search.py
+++ b/tests/test_run_grid_search.py
@@ -2,7 +2,10 @@
 
 import json
 
-from run_grid_search import GridSearchConfig, save_results
+import pytest
+from run_grid_search import GridSearchConfig, get_pixi_env, save_results
+from sampleworks.runs.schema import VALID_PIXI_ENVS
+from sampleworks.utils.guidance_constants import StructurePredictor
 from sampleworks.utils.guidance_script_arguments import JobResult
 
 
@@ -52,3 +55,19 @@ def test_save_results_normalizes_legacy_model_key(tmp_path) -> None:
     assert len(saved["runs"]) == 1
     assert saved["runs"][0]["model_name"] == "boltz2"
     assert "model" not in saved["runs"][0]
+
+
+def test_every_structure_predictor_has_a_valid_pixi_env() -> None:
+    """Each supported model resolves to a pixi environment declared in pyproject.
+
+    A model that reaches the grid search without a mapped environment only
+    fails inside the worker subprocess, so this is checked up front.
+    """
+    for predictor in StructurePredictor:
+        assert get_pixi_env(predictor) in VALID_PIXI_ENVS
+
+
+def test_get_pixi_env_rejects_unknown_model() -> None:
+    """An unrecognized model name fails with the valid options listed."""
+    with pytest.raises(ValueError, match="Unknown model: not-a-model"):
+        get_pixi_env("not-a-model")


### PR DESCRIPTION
## What breaks

Every protpardelle job in `run_experiments protpardelle` dies instantly:

```
ERROR | run_grid_search:301 - Job failed with exception: [Errno 2] No such file or directory: '.../wjq_139929586767296.results.pkl'
```

`get_pixi_env()` still had a hardcoded boltz/protenix/rf3 branch, so `protpardelle` fell through to `raise ValueError("Unknown model: protpardelle")`. That call is the first statement of `run_guidance_queue_script`, so no worker ever reached `subprocess.run` — which is why there are no `wjq_*.log` files and no `Running worker N: ...` line in the output.

`StructurePredictor.PROTPARDELLE`, the `protpardelle` pixi environment in `pyproject.toml`, and `env = "protpardelle"` in `experiments/protpardelle.toml` were all already in place. Only this function was missed.

## Why the error was unreadable

The `ValueError` is raised inside a `ProcessPoolExecutor` child, so it lands on the future. The collection loop never inspected the future — it went straight to opening `wjq_*.results.pkl`, which the dead worker never wrote, and the surrounding `except Exception` reported *that* `FileNotFoundError`. The real exception was discarded.

## Changes

- `get_pixi_env()` now resolves through a `MODEL_PIXI_ENVS` mapping keyed on `StructurePredictor`, so a newly added predictor cannot silently miss an environment.
- The result collector checks `completed.exception()` first and logs it with `log.opt(exception=...)`, reports a nonzero subprocess exit code, and points at the `wjq_*.log` path when the results pickle is genuinely missing.

## Tests

Two added to `tests/test_run_grid_search.py`: every `StructurePredictor` resolves to a name in `VALID_PIXI_ENVS`, and an unknown model still raises with the valid options listed.

**These have not been run** — `sampleworks` is not installable on the machine this was written on. Please run `pixi run -e protpardelle-dev tests -- -k grid_search` before merging.

## Follow-up, not in this PR

Once this lands, the `Running worker N: [...]` line will print the real command. If it shows `pixi run -e protpardelle ...` instead of a direct `.pixi/envs/protpardelle/bin/python`, the image has no baked protpardelle env and `get_pixi_env_python()` is falling back to a runtime solve on shared storage — works, but slow. That function hardcodes `/app` and does not route through `runner._pixi_project_dir()`, which is the one taught to honor `RUNTIME_PIXI` on `michaelanzuoni/fix-runtime-pixi-project-dir`.