### PR TITLE
Adding EXT_REPLAY_BASE_IMAGE in Astera Dockerfile

### DIFF
--- a/Dockerfile.astera
+++ b/Dockerfile.astera
@@ -16,6 +16,9 @@ ARG PIXI_WITH_CHECKPOINTS_IMAGE
 
 FROM ${PIXI_WITH_CHECKPOINTS_IMAGE} AS astera
 
+# Re-declare inside the stage so the base ref is usable below (a global ARG
+# before FROM is only in scope for the FROM line itself).
+ARG PIXI_WITH_CHECKPOINTS_IMAGE
 ARG EXT_VERSION=v0.1.8
 
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -26,7 +29,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     SHELL=/bin/bash \
     SAMPLEWORKS_PIXI_PROJECT_DIR=/app \
     SAMPLEWORKS_REQUIRE_PREBUILT_PIXI=1 \
-    SAMPLEWORKS_SKIP_ENV_PREPARE=1
+    SAMPLEWORKS_SKIP_ENV_PREPARE=1 \
+    EXT_REPLAY_BASE_IMAGE=${PIXI_WITH_CHECKPOINTS_IMAGE}
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected container configuration so the replay base image is properly carried through during setup.
  * Preserved existing environment preparation behavior while ensuring required build settings remain available at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->