### PR TITLE
feat(analysis): ship tortoize in the analysis pixi environments

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -17,10 +17,13 @@ environments:
   analysis:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/bioconda/
     indexes:
     - https://pypi.org/simple
     packages:
       osx-arm64:
+      - conda: https://conda.anaconda.org/bioconda/osx-arm64/libcifpp-8.0.1-hda5e58c_5.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/osx-arm64/tortoize-2.0.16-h639dec6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
@@ -45,6 +48,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-h30213e0_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dssp-4.5.8-py312h788f6ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
@@ -55,6 +59,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-17.0.0-hf07054f_71_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-17.0.0-h265dae0_71_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.86.0-h0419b56_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-python-1.86.0-py312hdeff4eb_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-h6caf38d_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-h6caf38d_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-h6caf38d_4.conda
@@ -95,6 +101,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.1.3-h3bfa610_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-17.0.0-py312ha814d7c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-17.0.0-py312hc40f475_2_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
@@ -214,6 +221,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
       p1:
+      - conda: https://conda.anaconda.org/bioconda/linux-64/libcifpp-8.0.1-h077b44d_3.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/linux-64/tortoize-2.0.16-haf24da9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.9.0-h0fbd49f_19.conda
@@ -276,6 +285,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-visual-tools-12.9.2-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.7.0-h00ab1b0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dssp-4.5.8-py312h897aeac_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.0-h27c8c51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.4.0-h236703b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.4.0-h26ba24d_2.conda
@@ -298,6 +308,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-17.0.0-h635bf11_71_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-17.0.0-h3f74fd7_71_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-7_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.86.0-hd24cca6_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.86.0-py312hf890105_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb03c661_4.conda
@@ -577,10 +589,13 @@ environments:
   analysis-dev:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/bioconda/
     indexes:
     - https://pypi.org/simple
     packages:
       osx-arm64:
+      - conda: https://conda.anaconda.org/bioconda/osx-arm64/libcifpp-8.0.1-hda5e58c_5.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/osx-arm64/tortoize-2.0.16-h639dec6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
@@ -605,6 +620,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.12.0-h30213e0_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dssp-4.5.8-py312h788f6ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
@@ -615,6 +631,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-17.0.0-hf07054f_71_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-17.0.0-h265dae0_71_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.86.0-h0419b56_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-python-1.86.0-py312hdeff4eb_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-h6caf38d_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-h6caf38d_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-h6caf38d_4.conda
@@ -655,6 +673,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.1.3-h3bfa610_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-17.0.0-py312ha814d7c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-17.0.0-py312hc40f475_2_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
@@ -803,6 +822,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
       p1:
+      - conda: https://conda.anaconda.org/bioconda/linux-64/libcifpp-8.0.1-h077b44d_3.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/linux-64/tortoize-2.0.16-haf24da9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.9.0-h0fbd49f_19.conda
@@ -865,6 +886,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-visual-tools-12.9.2-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.7.0-h00ab1b0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dssp-4.5.8-py312h897aeac_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.0-h27c8c51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.4.0-h236703b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.4.0-h26ba24d_2.conda
@@ -887,6 +909,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-17.0.0-h635bf11_71_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-17.0.0-h3f74fd7_71_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-7_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.86.0-hd24cca6_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.86.0-py312hf890105_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb03c661_4.conda
@@ -6763,6 +6787,72 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl
 packages:
+- conda: https://conda.anaconda.org/bioconda/linux-64/libcifpp-8.0.1-h077b44d_3.tar.bz2
+  sha256: f1272e81b441a8672da5220ae37655d43132aa5fb2e7292a785cfdbcd1cb53c5
+  md5: 744f92fe1a5a5e4441e5f345458dba64
+  depends:
+  - libboost >=1.86.0,<1.87.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libcifpp >=8.0.1,<9.0a0
+  size: 81979059
+  timestamp: 1753122802997
+- conda: https://conda.anaconda.org/bioconda/linux-64/tortoize-2.0.16-haf24da9_0.conda
+  sha256: c72c01b36bcefa3cc00a734979c4ce3e0baaa21d2571654bd7710030c3f83f2a
+  md5: 485b89a102c2c7110a4e43c213a38ff5
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - dssp >=4.5.6,<4.6.0a0
+  - libboost >=1.86.0,<1.87.0a0
+  - libcifpp >=8.0.1,<9.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - tortoize >=2.0.16,<3.0a0
+  size: 2006790
+  timestamp: 1763955066014
+- conda: https://conda.anaconda.org/bioconda/osx-arm64/libcifpp-8.0.1-hda5e58c_5.tar.bz2
+  sha256: 72860b9cd8ded1e208fbad80600a7a3492797f9766178ff1d44a3669f4c25c42
+  md5: c4ba7f5add026a47bd8cff87dcbc6d07
+  depends:
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libcifpp >=8.0.1,<9.0a0
+  size: 81957800
+  timestamp: 1753836285524
+- conda: https://conda.anaconda.org/bioconda/osx-arm64/tortoize-2.0.16-h639dec6_0.conda
+  sha256: a3fe5f0255a201eefe0ed757b77e1c55c35a0b85fa239ddbf893eae338417eef
+  md5: e1a69ac2eed031e3001d3e624203d97a
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - dssp >=4.5.6,<4.6.0a0
+  - libcifpp >=8.0.1,<9.0a0
+  - libcxx >=18
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - tortoize >=2.0.16,<3.0a0
+  size: 1806035
+  timestamp: 1763955340598
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
   sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
@@ -7899,6 +7989,30 @@ packages:
   run_exports: {}
   size: 2821960
   timestamp: 1780390159181
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dssp-4.5.8-py312h897aeac_1.conda
+  sha256: e8a6ee4419a133815b9bddb55e89cf2070192d3ae96817765b855dc6b42eb7b0
+  md5: e3089e2308bf59860018d37dfeab0045
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - numpy >=1.23,<3
+  - libboost >=1.86.0,<1.87.0a0
+  - libboost-python >=1.86.0,<1.87.0a0
+  - python_abi 3.12.* *_cp312
+  - pcre2 >=10.47,<10.48.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=78.2,<79.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - dssp >=4.5.8,<4.6.0a0
+  size: 212372127
+  timestamp: 1771430738528
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.0-h27c8c51_0.conda
   sha256: e798086d8a65d55dc4c51f5746705639c9a5f2eeb0b8fc50e6152cfc0d69a4e8
   md5: 06965b2f9854d0b15e0443ee81fe83dc
@@ -8368,6 +8482,43 @@ packages:
     - libblas >=3.11.0,<4.0a0
   size: 18804
   timestamp: 1779859100675
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.86.0-hd24cca6_5.conda
+  sha256: a17ae9fd2af96eac7c29072b3e345ec3c2af42f18e33102633ab4440c1168ef7
+  md5: 0d46f3db184ec649d41c3dfbfe986742
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=78.1,<79.0a0
+  - libgcc >=14
+  - liblzma >=5.8.1,<6.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  purls: []
+  run_exports: {}
+  size: 3151820
+  timestamp: 1766348212857
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.86.0-py312hf890105_5.conda
+  sha256: 7e4fd809fb926627c8c626d1265785c1d0420ea34aa910a0c901c48737474259
+  md5: 1630127107ab1cfb9ca9468f9318fa29
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.23,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - boost <0.0a0
+  - py-boost <0.0a0
+  license: BSL-1.0
+  purls: []
+  run_exports: {}
+  size: 124523
+  timestamp: 1766348623465
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb03c661_4.conda
   sha256: 2338a92d1de71f10c8cf70f7bb9775b0144a306d75c4812276749f54925612b6
   md5: 1d29d2e33fe59954af82ef54a8af3fe1
@@ -13701,6 +13852,30 @@ packages:
   run_exports: {}
   size: 2675614
   timestamp: 1780390235468
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/dssp-4.5.8-py312h788f6ed_1.conda
+  sha256: 316d214031c6acd59cdac8346c9d042d5f51c74b824f5b0ef429341e376467b7
+  md5: adbee3ba25baeed50ea9a38172c99693
+  depends:
+  - python
+  - __osx >=11.0
+  - python 3.12.* *_cpython
+  - libcxx >=19
+  - libboost >=1.86.0,<1.87.0a0
+  - icu >=78.2,<79.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libboost-python >=1.86.0,<1.87.0a0
+  - python_abi 3.12.* *_cp312
+  - pcre2 >=10.47,<10.48.0a0
+  - numpy >=1.23,<3
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - dssp >=4.5.8,<4.6.0a0
+  size: 211889910
+  timestamp: 1771430853846
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.18.1-h2b252f5_0.conda
   sha256: 8607d8d0b32f9f6fc61ea8c06b537486b78428a04516658222fa4d1d521af765
   md5: 9d928e6a62192141fb6540a3125b1345
@@ -14082,6 +14257,42 @@ packages:
     - libblas >=3.11.0,<4.0a0
   size: 18949
   timestamp: 1779859141315
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-1.86.0-h0419b56_5.conda
+  sha256: e5852889261db409a720c2c6a30930e0615c320184874b862c2f3141332ae701
+  md5: 0b2bb618d1c6e4a43fc2a13f128f55a0
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - icu >=78.1,<79.0a0
+  - libcxx >=19
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - boost-cpp <0.0a0
+  license: BSL-1.0
+  purls: []
+  run_exports: {}
+  size: 1991540
+  timestamp: 1766349001066
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-python-1.86.0-py312hdeff4eb_5.conda
+  sha256: ed62e2a4fa93de99dda3a79db77c7f595bd1377abe03b225ffd4aeefab38e108
+  md5: a1bd6dbd8795a23cae468f59a0795883
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - numpy >=1.23,<3
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - boost <0.0a0
+  - py-boost <0.0a0
+  license: BSL-1.0
+  purls: []
+  run_exports: {}
+  size: 104511
+  timestamp: 1766349822546
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-h6caf38d_4.conda
   sha256: 023b609ecc35bfee7935d65fcc5aba1a3ba6807cbba144a0730198c0914f7c79
   md5: 231cffe69d41716afe4525c5c1cc5ddd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,18 @@ platforms = ["osx-arm64"]
 pypi-dependencies = {"protenix" = "*", "einx" = "*", "triton" = "*"}
 platforms = ["linux-64"]
 
+[tool.pixi.feature.external-tools]
+# Binaries the eval scripts shell out to. Kept separate from the `analysis`
+# feature so adding one does not re-solve the model environments, and bioconda
+# is scoped here so everything else keeps solving against conda-forge alone.
+channels = ["conda-forge", "bioconda"]
+platforms = ["linux-64", "osx-arm64"]
+
+[tool.pixi.feature.external-tools.dependencies]
+# PDB-REDO's ramachandran/torsion z-score tool, invoked as a binary on PATH by
+# scripts/eval/run_and_process_tortoize.py.
+tortoize = ">=2.0.16,<3"
+
 [tool.pixi.feature.protpardelle]
 platforms = ["linux-64", "osx-arm64"]
 
@@ -159,8 +171,8 @@ gcc_linux-64 = ">=9,<13"
 gxx_linux-64 = ">=9,<13"
 
 [tool.pixi.environments]
-analysis = {features = ["analysis"]}
-analysis-dev = {features = ["analysis", "dev"]}
+analysis = {features = ["analysis", "external-tools"]}
+analysis-dev = {features = ["analysis", "dev", "external-tools"]}
 boltz = {features = ["boltz"]}
 boltz-analysis = {features = ["boltz", "analysis"]}
 boltz-dev = {features = ["boltz", "dev"]}

--- a/scripts/eval/EVALUATION.md
+++ b/scripts/eval/EVALUATION.md
@@ -3,10 +3,13 @@
 # External software requirements
 ## tortoize
 SampleWorks relies on tortoize to compute backbone and sidechain dihedral angle outliers.
-`tortoize` is free software and can be downloaded from https://github.com/PDB-REDO/tortoize.
-You should install it following their instructions and make sure it is available in the environment
-where you run SampleWorks. The script scripts/eval/run_and_process_tortoize.py will check for the
-`tortoize` executable before running and will raise an error if it is not available.
+`tortoize` is free software from https://github.com/PDB-REDO/tortoize, and it ships in the `analysis`
+and `analysis-dev` pixi environments via bioconda, so `pixi run -e analysis` (and the `external_tools`
+preset, which runs its jobs in `analysis`) already has it on `PATH`. No manual install is needed.
+
+If you invoke the script from some other environment, install tortoize yourself and make sure it is
+on `PATH`: scripts/eval/run_and_process_tortoize.py checks for the `tortoize` executable before
+running and raises an error if it is not available.
 
 ## phenix
 Information about the phenix package can be found at https://phenix-online.org/. Phenix requires a 


### PR DESCRIPTION
## Problem

`analyses/external_tools.toml` runs its tortoize job with `env = "analysis"`, but nothing ever put the binary there:

- `scripts/eval/run_and_process_tortoize.py` probes `subprocess.call("tortoize")` on `PATH` and raises `RuntimeError` if it is missing.
- The public `Dockerfile` apt-installs only build tooling, then `pixi install -e {boltz,protenix,rf3,analysis}`.
- `Dockerfile.astera` adds editors and network tools, nothing scientific.
- The `analysis` feature resolves to `[dependency-groups] analysis`, which is pure PyPI with no conda dependencies, so it could not supply a compiled binary.
- `pixi.lock` had zero matches for tortoize.

So `run_analysis external_tools` (and `all`) has never been able to run its tortoize job inside the image — it aborts before doing any work. `analyze_grid_search` with `rscc`/`lddt` is unaffected, which is presumably why this went unnoticed.

## Change

bioconda publishes tortoize 2.0.16 for linux-64, osx-arm64, linux-aarch64 and osx-64, so this adds it as a conda dependency rather than a source build.

It goes in a new `external-tools` feature attached to `analysis` and `analysis-dev`, rather than onto `analysis` directly, for two reasons:

- `analysis` is also a member of `boltz-analysis` and `boltz-osx`. Touching it re-solves those environments' PyPI requirements, which cannot even be done from macOS.
- The bioconda channel stays scoped to this feature, so every other environment keeps solving against conda-forge alone.

The resulting `pixi.lock` diff is **purely additive** — 211 inserted lines, zero removals. No existing package version moves. New packages are tortoize plus its runtime deps (libcifpp, dssp, libboost, libboost-python, pcre2) on the two workspace platforms.

No Dockerfile change is needed: the image already runs `pixi install -e analysis`, so it picks this up on the next build.

## Verification

Ran on osx-arm64 against a real structure in the analysis env:

```
$ pixi run -e analysis which tortoize
.pixi/envs/analysis/bin/tortoize

$ pixi run -e analysis tortoize tests/resources/1vme/1VME_single_001_density_input.cif
ramachandran-z: -0.8303307294845581
torsion-z:      -0.8385160565376282
residues:       399 entries
```

The JSON matches the shape `flatten_residues()` and `get_protein_level_z_scores()` parse — `model.1.residues[].ramachandran["z-score"]`, `.torsion["z-score"]`, `.pdb.seqNum`.

Not verified: the linux-64 solve is from the lockfile only, since I could not install that platform locally. CI's Docker build will exercise it.

## Not in this PR

`phenix.clashscore` has the same problem — `external_tools.toml` describes itself as needing "tortoize and phenix.clashscore", and phenix is likewise absent from the image. It needs a license, so it is not a conda dependency; it should either come from the existing `phenix` actl image or from the planned SBGrid `/programs` mount.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `tortoize` tool to the analysis environments.
  * The tool is automatically available on the command line when using the analysis environment.

* **Documentation**
  * Updated evaluation documentation with setup and usage instructions.
  * Added guidance on the error shown when `tortoize` is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->