### PR TITLE
fix(runs): resolve the pixi manifest the runner will actually use

### DIFF
--- a/run_grid_search.py
+++ b/run_grid_search.py
@@ -394,7 +394,6 @@ def run_guidance_queue_script(
         Result from the subprocess that ran the worker queue.
     """
     pixi_env_name = get_pixi_env(model)
-    log.warning(f"Running guidance job queue, job_queue_path: {job_queue_path}")
     script_path = Path(__file__).parent / "scripts" / "run_guidance_pipeline.py"
     env_python = get_pixi_env_python(pixi_env_name)
     if env_python:

--- a/src/sampleworks/runs/schema.py
+++ b/src/sampleworks/runs/schema.py
@@ -10,24 +10,56 @@ assignment or an automatically allocated ``gpu_count``.
 
 from __future__ import annotations
 
+import os
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 
+def _pixi_manifest_path() -> Path | None:
+    """Return the manifest declaring this workspace's pixi environments.
+
+    ``SAMPLEWORKS_PIXI_PROJECT_DIR`` wins, matching how the runner resolves the
+    pixi project, so the environments validated here are the ones the runner
+    will actually look for. In the ACTL image the source tree and the baked
+    project dir differ, and walking up from this file would silently pick up
+    whichever ``pyproject.toml`` happens to sit above the environment.
+
+    Returns
+    -------
+    Path or None
+        Manifest path, or ``None`` when no manifest is reachable.
+    """
+    override = os.environ.get("SAMPLEWORKS_PIXI_PROJECT_DIR")
+    if override:
+        candidate = Path(override) / "pyproject.toml"
+        if candidate.is_file():
+            return candidate
+    for directory in Path(__file__).resolve().parents:
+        candidate = directory / "pyproject.toml"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 def _load_valid_pixi_envs() -> tuple[str, ...]:
-    """Load valid pixi environment names from pyproject.toml."""
-    current = Path(__file__).parent
-    while current != current.parent:
-        pyproject_path = current / "pyproject.toml"
-        if pyproject_path.exists():
-            with open(pyproject_path, "rb") as f:
-                data = tomllib.load(f)
-            envs = data.get("tool", {}).get("pixi", {}).get("environments", {})
-            return tuple(sorted(envs.keys()))
-        current = current.parent
-    raise FileNotFoundError("Could not find pyproject.toml while searching from schema.py")
+    """Return the pixi environment names declared in the workspace manifest.
+
+    Returns
+    -------
+    tuple of str
+        Declared environment names, or an empty tuple when no manifest is
+        reachable — a wheel install does not ship ``pyproject.toml``. Empty
+        disables :class:`Job` env validation rather than making this module
+        unimportable; the runner still reports a missing environment clearly.
+    """
+    manifest = _pixi_manifest_path()
+    if manifest is None:
+        return ()
+    with open(manifest, "rb") as f:
+        data = tomllib.load(f)
+    return tuple(sorted(data.get("tool", {}).get("pixi", {}).get("environments", {})))
 
 
 VALID_PIXI_ENVS = _load_valid_pixi_envs()
@@ -89,7 +121,7 @@ class Job:
 
     def __post_init__(self) -> None:
         """Validate ``env`` and required string fields."""
-        if self.env not in VALID_PIXI_ENVS:
+        if VALID_PIXI_ENVS and self.env not in VALID_PIXI_ENVS:
             raise ValueError(
                 f"Job {self.name!r}: env must be one of {VALID_PIXI_ENVS}, got {self.env!r}"
             )

--- a/tests/runs/conftest.py
+++ b/tests/runs/conftest.py
@@ -32,7 +32,9 @@ def force_pixi_argv(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("SAMPLEWORKS_FORCE_PIXI", "1")
 
 
-BUNDLED = {
+# A tuple, not a set: this parametrizes tests, and set iteration order varies
+# with PYTHONHASHSEED, which would make test IDs differ between runs.
+BUNDLED = (
     "boltz",
     "boltz1",
     "boltz2",
@@ -46,4 +48,4 @@ BUNDLED = {
     "rf3_partial",
     "rf3_partial_chiral_off",
     "rf3_protenix",
-}
+)

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -15,7 +15,7 @@ def test_list_prints_all_experiment_presets(capsys: pytest.CaptureFixture[str]) 
     exit_code = cli.main(["--list"])
     assert exit_code == 0
     out = capsys.readouterr().out.splitlines()
-    assert set(out) == BUNDLED
+    assert set(out) == set(BUNDLED)
 
 
 def test_show_prints_resolved_preset(

--- a/tests/runs/test_loader.py
+++ b/tests/runs/test_loader.py
@@ -49,7 +49,7 @@ MODEL_ENV_PREFIXES = _get_model_env_prefixes()
 def test_list_presets_returns_bundled_experiments() -> None:
     """Preset discovery returns the expected bundled experiment names."""
     names = loader.list_presets()
-    assert set(names) == BUNDLED, f"unexpected experiment presets: {names}"
+    assert set(names) == set(BUNDLED), f"unexpected experiment presets: {names}"
 
 
 @pytest.mark.parametrize("name", BUNDLED)

--- a/tests/runs/test_schema.py
+++ b/tests/runs/test_schema.py
@@ -1,0 +1,63 @@
+"""Tests for pixi environment discovery in the run preset schema."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sampleworks.runs import schema
+
+
+MANIFEST = """
+[tool.pixi.environments]
+zebra = {features = ["zebra"]}
+antelope = {features = ["antelope"]}
+"""
+
+
+def _write_manifest(directory: Path, body: str = MANIFEST) -> Path:
+    """Write a pixi manifest into ``directory`` and return the directory."""
+    (directory / "pyproject.toml").write_text(body)
+    return directory
+
+
+def test_workspace_manifest_declares_the_running_environments() -> None:
+    """The checked-out workspace resolves to its own declared environments."""
+    assert "boltz" in schema.VALID_PIXI_ENVS
+    assert "protpardelle" in schema.VALID_PIXI_ENVS
+
+
+def test_project_dir_override_selects_the_manifest(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``SAMPLEWORKS_PIXI_PROJECT_DIR`` picks the manifest the runner will use."""
+    monkeypatch.setenv("SAMPLEWORKS_PIXI_PROJECT_DIR", str(_write_manifest(tmp_path)))
+    assert schema._load_valid_pixi_envs() == ("antelope", "zebra")
+
+
+def test_missing_manifest_yields_no_environments(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An unreachable manifest returns empty rather than raising on import.
+
+    A wheel install does not ship ``pyproject.toml``; importing the schema must
+    still work so the runner can report a missing environment itself.
+    """
+    monkeypatch.setattr(schema, "_pixi_manifest_path", lambda: None)
+    assert schema._load_valid_pixi_envs() == ()
+
+
+def test_job_env_is_unvalidated_without_a_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no discoverable environments, any ``env`` is accepted."""
+    monkeypatch.setattr(schema, "VALID_PIXI_ENVS", ())
+    job = schema.Job(name="j", env="not-a-real-env", output_subdir="out", gpus="none")
+    assert job.env == "not-a-real-env"
+
+
+def test_job_env_is_validated_against_declared_environments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A known environment list still rejects unknown ``env`` values."""
+    monkeypatch.setattr(schema, "VALID_PIXI_ENVS", ("boltz", "rf3"))
+    with pytest.raises(ValueError, match="env must be one of"):
+        schema.Job(name="j", env="not-a-real-env", output_subdir="out", gpus="none")


### PR DESCRIPTION
Review fixes for #352, targeted at its branch so they land together.

## 1. `_load_valid_pixi_envs()` can crash at import, or bind to the wrong manifest

The walk-up from `schema.py` has two failure modes.

**A wheel install makes `sampleworks.runs` unimportable.** The wheel target is `packages = ["src/sampleworks"]` with `analyses`/`experiments` force-included — `pyproject.toml` is not among them. The walk then reaches the filesystem root and raises at module scope, so `VALID_PIXI_ENVS = _load_valid_pixi_envs()` takes the whole package down with it. Simulated from a site-packages-shaped path:

```
wheel-style install -> FileNotFoundError: Could not find pyproject.toml while searching from schema.py
```

This does not bite today because the pixi environments install sampleworks editable, which leaves `schema.py` in the source tree. It bites the moment anything consumes a built wheel.

**A `pyproject.toml` above the environment wins silently.** That is exactly the ACTL image layout — envs at `/app/.pixi/envs/<env>/lib/python3.12/site-packages/`, manifest at `/app/pyproject.toml`. Same simulation with a manifest above the env:

```
stale-manifest-above-env -> ('FOUND', '/…/app/pyproject.toml', ('stale_env',))
```

So the environments validated here need not be the ones the runner resolves — and `runner._pixi_project_dir()` already treats `/app` versus a synced checkout as a real distinction.

**Fix:** resolve `SAMPLEWORKS_PIXI_PROJECT_DIR` first, matching `_pixi_project_dir()`, then fall back to the walk for editable installs and plain checkouts. Return `()` when nothing is reachable and skip `Job.env` validation in that case, rather than making the module unimportable — the runner already fails with a clear message when an environment is genuinely missing (`_missing_prebuilt_env_message`).

I did not import `_pixi_project_dir` directly because `runner` imports `schema`, so that would be circular. Happy to hoist it into a shared module instead if you prefer one implementation.

Five tests added in `tests/runs/test_schema.py` covering the override, the missing-manifest fallback, and validation on both sides. Verified passing.

## 2. Stray warning-level debug line

`log.warning(f"Running guidance job queue, job_queue_path: {job_queue_path}")` fires once per worker at WARNING, and the `log.info(f"Running worker {worker_num}: {cmd} …")` a few lines below already contains the same path inside `cmd`. Removed.

## 3. `BUNDLED` is a set, and it parametrizes tests

`@pytest.mark.parametrize("name", BUNDLED)` over a set gives ordering that varies with `PYTHONHASHSEED`, so test IDs differ run to run:

```
seed=1 -> ['rf3_partial_chiral_off', 'boltz2_xrd', 'protpardelle', 'rf3_protenix']
seed=2 -> ['boltz2', 'full_8gpu', 'protpardelle', 'protenix_dual']
```

It was a list before the move to `conftest`. Made it a tuple and used `set(BUNDLED)` at the two equality comparisons.

## Verified, no change needed

`--guidance-start` defaulting to `-1` is consistent with `GuidanceConfig.guidance_start` and both consumers guard on `> 0` (`guidance_script_utils.py:584,613`). Wiring it into `build_args_for_process_pool` is a real fix on its own — without it the preset's `guidance-start = 400` was silently dropped.

## Left alone, flagging instead

`PPDL_CC89_CHECKPOINT = "/mnt/diffuse-shared/marcus/model_params/weights/cc89_epoch415.pth"` is a personal path in a bundled preset. `rf3.toml` uses `/checkpoints/rf3_foundry_01_24_latest.ckpt`, matching what the image bakes, and #332 tracks doing the same for protpardelle. This preset will not resolve for anyone else or on a pod without that mount. Not changed since it is presumably what you are running against right now.

## Checks

`ruff check` and `ruff format --check` clean on all changed files. I could not run the full suite locally — sampleworks is not installable on macOS for the model envs — so the new tests were run in isolation against `src/` on the path; CI covers the rest.