### PR TITLE
feat(astera): put SBGrid on $PATH when /programs is mounted

### DIFF
--- a/Dockerfile.astera
+++ b/Dockerfile.astera
@@ -70,9 +70,9 @@ RUN install -m 0644 \
     && EXT_VERSION="${EXT_VERSION}" bash /usr/local/share/sampleworks/astera/install-ext.sh \
     && bash /usr/local/share/sampleworks/astera/install-ext-shell-hooks.sh
 
-# SBGrid lives on the shared sbgrid-programs PVC, auto-mounted read-only at
-# /programs by the actl catalog. /programs is created empty so the guarded init
-# is a clean no-op when the PVC is not mounted.
+# SBGrid lives on shared storage, mounted read-only at /programs for every
+# diffuse workspace by the actl catalog. /programs is created empty so the
+# guarded init is a clean no-op when the mount is absent.
 RUN mkdir -p /programs \
     && install -m 0644 \
         /usr/local/share/sampleworks/astera/sbgrid-shell.sh \

--- a/Dockerfile.astera
+++ b/Dockerfile.astera
@@ -34,6 +34,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \
+        bsdextrautils \
         ca-certificates \
         curl \
         dnsutils \
@@ -44,6 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         nano \
         ncdu \
         rsync \
+        tcsh \
         tini \
         tmux \
         vim \
@@ -56,7 +58,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && install -m 0755 /app/run_experiments.sh /usr/local/bin/run_experiments.sh \
     && install -m 0755 /app/run_all_models.sh /usr/local/bin/run_all_models.sh \
     && for cmd in \
-        bash curl dig emacs git htop nano ncdu ping rsync tini tmux vim wget zsh; do \
+        bash column csh curl dig emacs git htop nano ncdu ping rsync tini tmux vim wget zsh; do \
           command -v "${cmd}" >/dev/null 2>&1 || exit 1; \
         done
 
@@ -67,6 +69,15 @@ RUN install -m 0644 \
         /etc/profile.d/sampleworks-ext-shell.sh \
     && EXT_VERSION="${EXT_VERSION}" bash /usr/local/share/sampleworks/astera/install-ext.sh \
     && bash /usr/local/share/sampleworks/astera/install-ext-shell-hooks.sh
+
+# SBGrid lives on the shared sbgrid-programs PVC, auto-mounted read-only at
+# /programs by the actl catalog. /programs is created empty so the guarded init
+# is a clean no-op when the PVC is not mounted.
+RUN mkdir -p /programs \
+    && install -m 0644 \
+        /usr/local/share/sampleworks/astera/sbgrid-shell.sh \
+        /etc/profile.d/sbgrid-shell.sh \
+    && bash /usr/local/share/sampleworks/astera/install-sbgrid-shell-hooks.sh
 
 WORKDIR /home/dev
 

--- a/docker/astera/install-sbgrid-shell-hooks.sh
+++ b/docker/astera/install-sbgrid-shell-hooks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wire the guarded SBGrid init into every shell actl might open, mirroring
+# install-ext-shell-hooks.sh. Idempotent: re-running never double-appends.
+
+profile_script="/etc/profile.d/sbgrid-shell.sh"
+profile_comment="# Sampleworks: put SBGrid on \$PATH when /programs is mounted."
+profile_line="[ -r ${profile_script} ] && . ${profile_script}"
+
+touch /root/.bashrc /home/dev/.bashrc
+
+for profile_file in /etc/bash.bashrc /root/.bashrc /home/dev/.bashrc /etc/zsh/zshrc /etc/zsh/zprofile; do
+    if [ ! -e "${profile_file}" ]; then
+        continue
+    fi
+    if grep -Fqs "${profile_line}" "${profile_file}"; then
+        continue
+    fi
+    printf '\n%s\n%s\n' "${profile_comment}" "${profile_line}" >> "${profile_file}"
+done

--- a/docker/astera/sbgrid-shell.sh
+++ b/docker/astera/sbgrid-shell.sh
@@ -1,11 +1,10 @@
 # Put the SBGrid collection on $PATH when it is mounted.
 #
-# SBGrid is a site installation on the shared `sbgrid-programs` PVC, which the
-# actl catalog auto-mounts read-only at /programs for every diffuse profile. It
-# is not part of this image — the collection is well over a terabyte — so this
-# script must be a no-op whenever the mount is absent (any non-diffuse
-# workspace, or a run with --no-mount). Every step is guarded accordingly:
-# /programs is an ordinary empty directory without the PVC.
+# SBGrid is a site installation on shared storage, which actl mounts read-only
+# at /programs for every diffuse workspace. It is not part of this image, so
+# this script must be a no-op whenever the mount is absent (any non-diffuse
+# workspace). Every step is guarded accordingly: without the mount, /programs
+# is an ordinary empty directory.
 #
 # Set SBGRID_NO_AUTOINIT=1 before shell start to opt out.
 

--- a/docker/astera/sbgrid-shell.sh
+++ b/docker/astera/sbgrid-shell.sh
@@ -1,0 +1,20 @@
+# Put the SBGrid collection on $PATH when it is mounted.
+#
+# SBGrid is a site installation on the shared `sbgrid-programs` PVC, which the
+# actl catalog auto-mounts read-only at /programs for every diffuse profile. It
+# is not part of this image — the collection is well over a terabyte — so this
+# script must be a no-op whenever the mount is absent (any non-diffuse
+# workspace, or a run with --no-mount). Every step is guarded accordingly:
+# /programs is an ordinary empty directory without the PVC.
+#
+# Set SBGRID_NO_AUTOINIT=1 before shell start to opt out.
+
+if [ -z "${SBGRID_NO_AUTOINIT:-}" ] && [ -z "${SBGRID_INITIALISED:-}" ] && [ -r /programs/sbgrid.shrc ]; then
+    SBGRID_INITIALISED=1
+    export SBGRID_INITIALISED
+    # sbgrid.shrc runs commands that return non-zero benignly, so it aborts
+    # under `set -e` and would take the whole shell with it. It is also chatty
+    # on first run and writes into $HOME. Neither should be able to break shell
+    # startup, hence the redirect and the `|| true`.
+    . /programs/sbgrid.shrc >/dev/null 2>&1 || true
+fi


### PR DESCRIPTION
Astera now installs the SBGrid collection once on a shared `sbgrid-programs` PVC, which the actl catalog auto-mounts **read-only at /programs** for every diffuse profile. The mount arrives regardless of image — but on this image a scientist still had to run three manual steps before phenix worked:

```sh
apt-get update && apt-get install -y tcsh bsdextrautils
ln -sfn /mnt/sbgrid-programs /programs
source /programs/sbgrid.shrc
```

The symlink goes away on the actl side. This PR removes the other two, so `--image sampleworks` lands you in a shell where phenix just works.

### Why tcsh is not optional

`/programs/sbgrid.shrc` aborts with *"requires the C shell"* when `/bin/csh` is missing and sets up **nothing at all** — the entire collection stays invisible. `bsdextrautils` provides `column(1)`, which SBGrid's `sbgrid-obsolete` helper shells out to on every title lookup. Both added to the existing verification loop.

### The shell init

Follows the existing ext-shell pattern (`/etc/profile.d/` + `install-*-shell-hooks.sh`). Guarded so it cannot break shells with no collection: `/programs` is created empty in the image, so a non-diffuse workspace or a `--no-mount` run is a clean no-op.

The `|| true` is **load-bearing** — sbgrid.shrc runs commands that return non-zero benignly, so sourcing it under `set -e` kills the shell. Verified on a live pod; it's why my first attempt at this failed.

### Verified

Against the real collection, on the current image, with the PVC mounted read-only exactly as the catalog will:

- interactive shell resolves `phenix.molprobity` with **no setup**, and scores 1CRN correctly (MolProbity 0.56, 0.00% Ramachandran outliers)
- `bash -lc 'phenix.version'` works for non-interactive callers
- `pixi` unaffected (0.71.2) — the analysis env and SBGrid coexist
- absent mount is a clean no-op under both plain and `set -e` shells
- `SBGRID_NO_AUTOINIT=1` opts out

### Note

This brings phenix and the ~3,200 other SBGrid commands. **tortoize is not an SBGrid title** and still comes from `pixi run -e analysis`.

Depends on Astera-org/asteractl#138 + #139 for the /programs mount; harmless to merge before them (no mount → no-op).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the Astera image with additional shell utilities and command-line tools.
  * Added automatic SBGrid shell initialization for Bash and Zsh environments.
  * Added support for creating and using the `/programs` directory when available.

* **Bug Fixes**
  * Prevented duplicate shell startup entries.
  * Reduced initialization errors from disrupting shell startup.
  * Added safeguards to skip unavailable configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->