### PR TITLE
fix(docker): stop shipping empty pixi environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,14 +127,42 @@ RUN --mount=type=bind,from=checkpoints,target=/ck \
 # IMPORTANT: keep these installs in a single RUN. Splitting them into separate
 # Docker layers duplicates shared conda packages (numpy, CUDA libs, etc.) and can
 # add tens of GB to the image.
-RUN --mount=type=cache,target=/root/.cache/pixi \
-    --mount=type=cache,target=/root/.cache/rattler \
+#
+# The `rm -rf` and the assertion below are both load-bearing. Published images
+# have shipped with all five environments as empty shells: the directories and
+# pixi's own bookkeeping in conda-meta present, but no package records, no bin/,
+# no lib/. `pixi install --frozen` then reports "The <env> environment has been
+# installed" against them and exits 0, so the breakage is invisible at build
+# time and only surfaces when a scientist finds /app/.pixi/envs/protenix has no
+# python. `SAMPLEWORKS_REQUIRE_PREBUILT_PIXI=1` makes the runner refuse to fall
+# back, so the image promises environments it does not carry.
+#
+# Clearing the prefix first forces a genuine install even when a stale or stub
+# prefix arrives from a cached layer, the base image, or the registry
+# buildcache. The per-environment check then makes an empty env fail the build
+# instead of shipping: a directory that exists but has no interpreter is exactly
+# the state that got published, and `pixi install` alone does not catch it.
+#
+# `/root/.cache/pixi` is deliberately not cached across builds — it carries
+# pixi's own "is this environment current" state, which is the thing that can
+# disagree with a prefix restored from a different build. The rattler and uv
+# caches stay: they hold downloaded packages and wheels, are what actually make
+# rebuilds fast, and were verified not to affect what lands in the layer.
+RUN --mount=type=cache,target=/root/.cache/rattler \
     --mount=type=cache,target=/root/.cache/uv \
+    rm -rf /app/.pixi/envs && \
     pixi install -e boltz --frozen && \
     pixi install -e protenix --frozen && \
     pixi install -e rf3 --frozen && \
     pixi install -e protpardelle --frozen && \
-    pixi install -e analysis --frozen
+    pixi install -e analysis --frozen && \
+    for env in boltz protenix rf3 protpardelle analysis; do \
+        test -x "/app/.pixi/envs/${env}/bin/python" || { \
+            echo "FATAL: pixi environment '${env}' has no interpreter at /app/.pixi/envs/${env}/bin/python."; \
+            echo "       pixi reported success but installed nothing — refusing to ship an empty environment."; \
+            exit 1; \
+        }; \
+    done
 
 # A GPU is not required to build the image. Pre-compile CUDA extensions only when
 # the builder exposes NVIDIA devices; if present, failures should stop the build.


### PR DESCRIPTION
Published images ship all five pixi environments as **empty shells**. Reported by @Feng-Yu and @marcuscollins looking for the prebuilt protenix env.

```
/app/.pixi/envs/protenix   20K   conda-meta: history, pixi, pixi_env_prefix   <- no package records
/app/.pixi/envs/protenix/bin/python                                            <- does not exist
/app total: 1.6 MB          (alongside 12 GB of checkpoints in the same image)
```

## Important: the Dockerfile is not the bug

I built the real thing to check — `pixi install -e protenix --frozen` against the real `pixi.lock`, on `linux/amd64`:

```
The protenix environment has been installed.        (349 s)
13G  /app/.pixi/envs/protenix
240  conda-meta entries
bin/python -> python3.12    →  runs, 3.12.13
```

and it **survives into the exported image**, not just the build. I also poisoned the prefix to look exactly like the shipped one (metadata present, zero packages, matching lock hash) and the current step still repaired it to a full 13 GB env.

So the build instructions are correct, and **this PR is not a root-cause fix**. I could not reproduce the failure in any local configuration — including three mechanisms I tested and disproved (rattler hardlinking out of a cache mount, a missing `__cuda` virtual package, and pixi state cached across builds).

## What this PR does

Given the above, it is insurance rather than a cure:

- **A per-environment interpreter check.** `pixi install` reporting success is demonstrably not evidence that anything was installed — that is exactly how five empty environments shipped. This turns that into a build failure. Verified it fails (`exit code: 1`) when the interpreter is missing.
- **`rm -rf /app/.pixi/envs` before installing**, so a stale or stub prefix arriving from a cached layer can't influence the result.
- **Drops the `/root/.cache/pixi` mount**, which carries pixi's own "is this environment current" state — the one cache whose contents can disagree with a prefix restored from a different build. The rattler and uv caches stay; they hold the downloads that make rebuilds fast, and I verified they don't change what lands in the layer.

## What actually needs to happen

Since the Dockerfile is correct, the published image must have come from a build whose environment differed — and the remaining candidate I can't rule out is the registry buildcache (`cache-from`/`cache-to: type=registry … mode=max`) importing a layer with the metadata but not the package files. That would produce exactly this.

**Someone with access should rebuild the image with `:buildcache` busted.** I don't have dispatch rights on this repo. With this PR merged first, that rebuild either produces working environments or fails loudly instead of silently shipping empties.

## Meanwhile

`SAMPLEWORKS_REQUIRE_PREBUILT_PIXI=1` makes the runner refuse to fall back, so the image currently promises environments it doesn't carry. Until a good image exists, building in the synced checkout works and is deterministic against the same lockfile:

```
cd ~/workspace && pixi install -e protenix --frozen
```
