### PR TITLE
fix(astera): keep pixi's cache off the NFS home volume

### DIFF
--- a/Dockerfile.astera
+++ b/Dockerfile.astera
@@ -30,7 +30,34 @@ ENV DEBIAN_FRONTEND=noninteractive \
     SAMPLEWORKS_PIXI_PROJECT_DIR=/app \
     SAMPLEWORKS_REQUIRE_PREBUILT_PIXI=1 \
     SAMPLEWORKS_SKIP_ENV_PREPARE=1 \
-    EXT_REPLAY_BASE_IMAGE=${PIXI_WITH_CHECKPOINTS_IMAGE}
+    EXT_REPLAY_BASE_IMAGE=${PIXI_WITH_CHECKPOINTS_IMAGE} \
+    PIXI_CACHE_DIR=/var/cache/pixi
+
+# Keep pixi's cache off the NFS-backed home volume.
+#
+# ACTL mounts $HOME from an nfs-shared PVC whose export squashes every write to
+# nobody (65534), while the workspace container runs as root. pixi puts uv's git
+# cache under its own cache dir, so a `git+https://` dependency gets cloned into
+# a tree root does not own, and git refuses to touch it:
+#
+#   fatal: detected dubious ownership in repository at
+#   '/home/dev/.cache/rattler/cache/uv-cache/git-v0/db/<hash>'
+#
+# which surfaces as an unrelated-looking "failed to solve the pypi requirements"
+# and blocks any environment with a git dependency (protpardelle, today).
+#
+# `git config --global --add safe.directory` is not a usable fix here: this
+# image ships git 2.34.1, where only an exact path or the bare `*` is honoured —
+# prefix globs are silently ignored (verified). The cache paths are
+# content-hashed, so exact entries are whack-a-mole, and `*` would disable the
+# ownership check on genuinely shared volumes like /mnt/diffuse-shared too.
+#
+# pixi already redirects its repodata and pypi-mapping caches off network
+# filesystems on its own; it just does not do the same for the uv cache. Setting
+# the cache root to container-local disk covers all of them. The trade-off is
+# that the download cache no longer survives a pod restart — environments
+# themselves live in the synced checkout and are unaffected.
+RUN mkdir -p /var/cache/pixi
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bash \


### PR DESCRIPTION
Any pixi environment with a git dependency fails to solve in an ACTL workspace. protpardelle is the one people hit — reported by @mewall:

```
failed to solve the pypi requirements of environment 'protpardelle-dev'
...
fatal: detected dubious ownership in repository at
'/home/dev/.cache/rattler/cache/uv-cache/git-v0/db/0d3cb18a2d15b11d'
```

## Cause

ACTL mounts `$HOME` from an `nfs-shared` PVC whose export squashes every write to `nobody` (65534), while the workspace container runs as **root**. pixi places uv's git cache under its own cache dir, so a `git+https://` dependency is cloned into a tree root doesn't own — and git refuses to touch it.

Confirmed on the reporting pod: that directory is owned by `65534`, `$HOME` is the NFS PVC, and the user is uid 0. The error surfaces as an unrelated-looking "failed to solve the pypi requirements", which is why it reads like a lockfile problem.

## Fix

Point `PIXI_CACHE_DIR` at container-local disk. Root then owns the cache and the clone succeeds — verified the git cache lands at `/var/cache/pixi/uv-cache/git-v0` owned by uid 0.

## Why not the obvious alternatives

**`git config --global --add safe.directory`** — not usable. This image ships **git 2.34.1**, where only an exact path or the bare `*` is honoured. I tested all four forms:

| value | result |
| --- | --- |
| *(none)* | blocked |
| exact path | **allowed** |
| `/home/dev/.cache/*` | blocked |
| `/home/dev/.cache/rattler/cache/uv-cache/git-v0/db/*` | blocked |
| `*` | **allowed** |

Cache paths are content-hashed, so exact entries are whack-a-mole, and `*` would also disable the ownership check on genuinely shared volumes like `/mnt/diffuse-shared`.

**`UV_CACHE_DIR`** — pixi ignores it and keeps the uv cache under its own root (tested).

## Note

pixi already redirects its `repodata` and `pypi-mapping` caches off network filesystems on its own — those `WARN cache … is on a network/parallel filesystem` lines in the report are it doing exactly that. It just doesn't extend the same treatment to the uv cache. This applies it to all of them.

**Trade-off:** the download cache no longer survives a pod restart. Environments live in the synced checkout and are unaffected, so the cost is re-downloading packages when an env is created or updated.

Workaround until this merges: `export PIXI_CACHE_DIR=/var/cache/pixi` in the pod, or `git config --global --add safe.directory '*'`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Astera container caching by using a container-local cache directory.
  * Prevented cache ownership issues that could affect package and environment setup.

* **Documentation**
  * Added comments explaining the cache location and related storage considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->