### PR TITLE
fix(astera): stop SBGrid shadowing system curl in diffuse workspaces

### DIFF
--- a/docker/astera/sbgrid-shell.sh
+++ b/docker/astera/sbgrid-shell.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=sh
 # Put the SBGrid collection on $PATH when it is mounted.
 #
 # SBGrid is a site installation on shared storage, which actl mounts read-only
@@ -6,14 +7,101 @@
 # workspace). Every step is guarded accordingly: without the mount, /programs
 # is an ordinary empty directory.
 #
+# Sourced from /etc/profile.d, /etc/bash.bashrc and /etc/zsh/zshrc, so it has
+# to stay POSIX and must not rely on word splitting: zsh does not split
+# unquoted parameters, which rules out the usual `IFS=: ; for d in $PATH` loop.
+#
 # Set SBGRID_NO_AUTOINIT=1 before shell start to opt out.
 
-if [ -z "${SBGRID_NO_AUTOINIT:-}" ] && [ -z "${SBGRID_INITIALISED:-}" ] && [ -r /programs/sbgrid.shrc ]; then
+# sbgrid.shrc is written in bash/zsh syntax and says so itself ("Unsupported
+# Shell - supported shells are bash and zsh"). It never gets the chance to say
+# it under dash: the `[[ ]]` in its first lines is a parse error there, which
+# takes down the shell that sourced it -- `|| true` cannot catch that, and
+# /bin/sh is dash on this image, so `sh -l` died outright. Only offer the
+# collection to the two shells that can actually read it.
+if [ -z "${SBGRID_NO_AUTOINIT:-}" ] && [ -z "${SBGRID_INITIALISED:-}" ] \
+   && [ -r /programs/sbgrid.shrc ] \
+   && { [ -n "${BASH_VERSION:-}" ] || [ -n "${ZSH_VERSION:-}" ]; }; then
     SBGRID_INITIALISED=1
     export SBGRID_INITIALISED
+
+    _sbgrid_path_before="${PATH}"
+
     # sbgrid.shrc runs commands that return non-zero benignly, so it aborts
     # under `set -e` and would take the whole shell with it. It is also chatty
     # on first run and writes into $HOME. Neither should be able to break shell
     # startup, hence the redirect and the `|| true`.
     . /programs/sbgrid.shrc >/dev/null 2>&1 || true
+
+    # sbgrid.shrc PREPENDS /programs/x86_64-linux/system/sbgrid_bin, a dispatch
+    # directory holding an entry for every one of the ~13.6k binaries in the
+    # collection. Thirty of those names collide with system binaries -- `curl`
+    # and the whole perl toolchain -- so the collection silently wins every one
+    # of those lookups.
+    #
+    # That is not survivable here. SBGrid links its binaries against a host OS,
+    # not against this image: its `curl` (the `current` symlink still points at
+    # 7.50.3, from 2016) needs the NSS libraries libssl3/libnss3/libnspr4,
+    # which this image does not ship, so the shadowed `curl` does not merely
+    # lag the system one -- it fails to start at all:
+    #
+    #   curl: error while loading shared libraries: libssl3.so: cannot open
+    #   shared object file: No such file or directory
+    #
+    # which breaks `curl | bash` installers and anything shelling out to curl
+    # (`ext update` among them). Installing the missing NSS libraries would
+    # only move the problem: the collection's newer curl 8.9.1 wants
+    # libssl.so.1.1, absent here too.
+    #
+    # So move everything sbgrid.shrc prepended to the END of $PATH. Every
+    # SBGrid title still resolves -- phenix, sbgrid-installer and friends are
+    # not shadowed by anything -- but the image's own binaries now win the
+    # thirty collisions, which is the same rule every other actl workspace
+    # image follows (see actl-packages.env in the docker-images repo: images
+    # are given the SBGrid prerequisites but do not auto-source the collection,
+    # precisely because this shadowing is a nasty surprise).
+    if [ "${PATH}" != "${_sbgrid_path_before}" ]; then
+        _sbgrid_kept=""
+        _sbgrid_moved=""
+        _sbgrid_rest="${PATH}"
+        while [ -n "${_sbgrid_rest}" ]; do
+            case "${_sbgrid_rest}" in
+                *:*)
+                    _sbgrid_head="${_sbgrid_rest%%:*}"
+                    _sbgrid_rest="${_sbgrid_rest#*:}"
+                    ;;
+                *)
+                    _sbgrid_head="${_sbgrid_rest}"
+                    _sbgrid_rest=""
+                    ;;
+            esac
+            [ -n "${_sbgrid_head}" ] || continue
+
+            # Demote only what this sourcing added, and only under /programs:
+            # an entry the user already had stays exactly where it was.
+            case "${_sbgrid_head}" in
+                /programs|/programs/*)
+                    case ":${_sbgrid_path_before}:" in
+                        *":${_sbgrid_head}:"*)
+                            _sbgrid_kept="${_sbgrid_kept:+${_sbgrid_kept}:}${_sbgrid_head}"
+                            ;;
+                        *)
+                            _sbgrid_moved="${_sbgrid_moved:+${_sbgrid_moved}:}${_sbgrid_head}"
+                            ;;
+                    esac
+                    ;;
+                *)
+                    _sbgrid_kept="${_sbgrid_kept:+${_sbgrid_kept}:}${_sbgrid_head}"
+                    ;;
+            esac
+        done
+
+        PATH="${_sbgrid_kept:+${_sbgrid_kept}:}${_sbgrid_moved}"
+        PATH="${PATH%:}"
+        export PATH
+
+        unset _sbgrid_kept _sbgrid_moved _sbgrid_rest _sbgrid_head
+    fi
+
+    unset _sbgrid_path_before
 fi


### PR DESCRIPTION
## Summary

Since #362 the sampleworks image auto-sources `/programs/sbgrid.shrc` so phenix works out of the box. That call prepends SBGrid's dispatch directory to `$PATH`, putting roughly 13,600 entries ahead of the image's own binaries. Thirty of those names collide with system binaries, and one of the thirty is `curl`, which is broken in a container. Scientists in the diffuse namespace hit it as soon as they ran any `curl | bash` installer or `ext update`. This moves what sbgrid.shrc prepends to the end of `$PATH` instead, keeping the whole collection reachable while the image wins the collisions.

## Changes

`docker/astera/sbgrid-shell.sh`:

- After sourcing sbgrid.shrc, move every `/programs` entry it prepended to the end of `$PATH`. Entries the user already had stay where they were. The tokenizer is pure parameter expansion because this file is sourced into zsh too, and zsh does not word-split unquoted parameters.
- Only source sbgrid.shrc under bash and zsh. It is written in their syntax and the `[[ ]]` on its first lines is a parse error under dash, which kills the sourcing shell rather than returning non-zero, so the existing `|| true` could not catch it.

### Why curl specifically

SBGrid links against a host OS, not this image. The `current` symlink still points at curl 7.50.3 from 2016, which wants `libssl3.so`, `libnss3.so` and `libnspr4.so`. None of them ship here, so the binary does not merely lag the system one, it fails to start:

```
/programs/x86_64-linux/system/curl/current/bin/curl: error while loading shared
libraries: libssl3.so: cannot open shared object file: No such file or directory
```

Installing the NSS libraries would only move the problem. The collection's newer curl 8.9.1 wants `libssl.so.1.1`, which is also absent. Ordering is the fix that holds.

The other 29 collisions are the perl toolchain. Those run, so nothing was visibly broken, but a 2016 curl and SBGrid's perl silently winning over the image's is the surprise `actl-packages.env` in docker-images already warns about. That file is why every other actl workspace image gets the SBGrid prerequisites but does not auto-source the collection.

## Testing

Verified against the live pods in diffuse rather than a rebuild, by staging the candidate script and sourcing it in a clean shell:

- Denis's original repro, `curl -fsSL https://dynamicpdb.com/install.sh`, goes from the loader error to HTTP 200.
- `curl` resolves to `/usr/bin/curl` 7.81.0 and `perl` to `/usr/bin/perl` under bash and zsh.
- `phenix.version` still resolves through `sbgrid_bin` and prints Phenix 2.1 release 6048, so #362's goal is intact.
- `sh -l` survives now. On main it exits 1 and produces no shell at all.
- Sourcing twice is a no-op, and `SBGRID_NO_AUTOINIT=1` still opts out.
- With no `/programs` mount, all three shells source it clean and leave `$PATH` byte-identical, which is the non-diffuse workspace case.

## Rollout

Needs a rebuild and republish of the astera image, then scientists pick it up on their next `actl pod up`. Running pods keep the broken ordering until they cycle. Anyone blocked right now can put the system binaries back in front for the current shell:

```sh
export PATH="$(echo "$PATH" | tr ':' '\n' | grep -v 'system/sbgrid_bin' | paste -sd: -):/programs/x86_64-linux/system/sbgrid_bin"
```

or run `SBGRID_NO_AUTOINIT=1 bash -l` if they do not need SBGrid in that shell.

No regression test here. `tests/` is pytest for the model code and there is no shell-test harness to extend, and the interesting behaviour only appears with the `/programs` mount, which CI does not have. Worth adding a small harness with a stub sbgrid.shrc if this area moves again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell compatibility by limiting automatic SBGrid initialization to supported shells.
  * Prevented SBGrid tools from unexpectedly taking precedence over existing system commands.
  * Preserved existing PATH entries and their ordering during SBGrid setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->